### PR TITLE
Show spinner when waiting for search results

### DIFF
--- a/custom-theme/search.html
+++ b/custom-theme/search.html
@@ -13,7 +13,9 @@
   </form>
 
   <div id="mkdocs-search-results">
-    Sorry, page not found.
+    <div>
+      <i class="fa fa-cog fa-spin fa-4x"></i>
+    </div>
   </div>
 
 {% endblock %}


### PR DESCRIPTION
"Sorry, page not found." is shown before search results are returned.