### PR TITLE
Initial support for unlimited toc nesting

### DIFF
--- a/custom-theme/child_url.html
+++ b/custom-theme/child_url.html
@@ -1,0 +1,6 @@
+{% if child.url %}
+  {{ child.url }}
+{% else %}
+  {% set child=child.children[0] %}
+  {% include "child_url.html" %}
+{% endif %}

--- a/custom-theme/css/custom.css
+++ b/custom-theme/css/custom.css
@@ -612,3 +612,7 @@ code {
 li.toctree-l3 {
     padding-left: 20px;
 }
+
+li.active {
+    background-color: #F2853F !important;
+}

--- a/custom-theme/documentation.html
+++ b/custom-theme/documentation.html
@@ -19,15 +19,16 @@
     </div>
     <div class="row">
         {% for nav_item in nav %}
-            {% if nav_item.title != 'Home' and nav_item.title != 'Download' and nav_item.title != 'Documentation' and nav_item.title != 'Community' and nav_item.title != 'Events' %}
+            {% if 'Chapter' in nav_item.title %}
                 <div class="col-md-6 doc-section">
                     <div class="outline-title">{{ nav_item.title }}</div>
                     <p>{{ config.extra.chapters[nav_item.title] }}</p>
                     {% if nav_item.children %}
                         <ul>
                             {% for nav_item in nav_item.children %}
+                                {% set child=nav_item %}
                                 <li class="{% if nav_item.active%}current{%endif%}">
-                                    <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+                                    <a href="{% include "child_url.html" %}">{{ nav_item.title }}</a>
                                 </li>
                             {% endfor %}
                         </ul>

--- a/custom-theme/nested_toc.html
+++ b/custom-theme/nested_toc.html
@@ -1,0 +1,22 @@
+{% if nav_item.children %}
+  {% set child=nav_item.children[0] %}
+  <li><a href="{% include "child_url.html" %}">{{ nav_item.title }}</a>
+    {% if nav_item.active %}
+      <ul class="current-toc">
+          {% for nav_item in nav_item.children %}
+              {% include "nested_toc.html" %}
+          {% endfor %}
+      </ul>
+    {% endif %}
+  </li>
+{% else %}
+  {% if nav_item.active %}
+    <li class="active">
+      {{ nav_item.title }}
+    </li>
+  {% else %}
+    <li>
+      <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+    </li>
+  {% endif %}
+{% endif %}

--- a/custom-theme/toc.html
+++ b/custom-theme/toc.html
@@ -11,24 +11,10 @@
         </div>
     </div>
     <ul class="nav bs-sidenav">
-        {% for nav_item in nav %}
-            {% if nav_item.title != 'Home' and nav_item.title != 'Download' and nav_item.title != 'Documentation' and nav_item.title != 'Community' and nav_item.title != 'Events' %}
-                <li class="main"><a href="{{ nav_item.children[0].url }}">{{ nav_item.title }}</a></li>
-                {% if nav_item.children and nav_item.active %}
-                    <ul class="current-toc">
-                        {% for nav_item in nav_item.children %}
-                            <li class="toctree-l2"><a href="{{ nav_item.url }}">{{ nav_item.title }}</a></li>
-                            {% if nav_item.active %}
-                                {% for toc_item in toc %}
-                                    {% for toc_item in toc_item.children %}
-                                        <li class="toctree-l3"><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
-                                    {% endfor %}
-                                {% endfor %}
-                            {% endif %}
-                        {% endfor %}
-                    </ul>
-                {% endif %}
-            {% endif %}
-        {% endfor %}
+      {% for nav_item in nav %}
+        {% if 'Chapter' in nav_item.title %}
+          {% include 'nested_toc.html' %}
+        {% endif %}
+      {% endfor %}
     </ul>
 </div>


### PR DESCRIPTION
This PR is not ready to be merged.  Submitting so others can start playing with it.  The bread crumbs need to be change to support nesting.  The toc styles need to be re-worked to better reflect what's currently selected.

Nesting support will allow us to nest the toc to arbitrary depths.  For example:

- Chapter 4 - Mynewt OS:
    - 'Overview': 'os/mynewt_os.md'
    - 'Scheduler/Context Switching': 'os/context_switch.md'
    - 'Time': 'os/time.md'
    - 'Tasks': 'os/task.md'
    - 'Event Queues': 'os/event_queue.md'
    - The Mynewt difference:
      - Faster:
        - 'Faster': 'os/faster.md'
        - 'Speedier': 'os/speedier.md'
      - 'Stronger': 'os/stronger.md'
      - 'Harder': 'os/harder.md'
    - 'Semaphores': 'os/semaphore.md'

