### PR TITLE
Remove incorrect OpenOCD 0.8.0 requirement.

### DIFF
--- a/docs/os/get_started/cross_tools.md
+++ b/docs/os/get_started/cross_tools.md
@@ -41,14 +41,12 @@ computer to interface with the JTAG debug connector on a variety of boards.  A
 JTAG connection lets you debug and test embedded target devices. For more on
 OpenOCD go to [http://openocd.org](http://openocd.org).
 
-Currently, only OpenOCD 0.8.0 is supported.
-
 ```no-highlight
 $ brew install open-ocd
 $ which openocd
 /usr/local/bin/openocd
 $ ls -l $(which openocd)
-lrwxr-xr-x  1 <user>  admin  36 Sep 17 16:22 /usr/local/bin/openocd -> ../Cellar/open-ocd/0.8.0/bin/openocd
+lrwxr-xr-x  1 <user>  admin  36 Sep 17 16:22 /usr/local/bin/openocd -> ../Cellar/open-ocd/0.9.0/bin/openocd
 ```
 
 <br>


### PR DESCRIPTION
Newt works with OpenOCD 0.9.0 as well (not just 0.8.0).  I am the one who added this incorrect note originally.  I didn't realize we had added 0.9.0 support!