### PR TITLE
Nimble doc fixes

### DIFF
--- a/docs/network/ble/ini_stack/ble_ini_intro.md
+++ b/docs/network/ble/ini_stack/ble_ini_intro.md
@@ -1,12 +1,13 @@
 ## Nimble stack initialization
 
-We are now going to explain how to setup your application to initialize the nimble stack and to get the basic stack, and its required modules, initialized and up and running. Note that the code shown here is an example of what is required for nimble stack operation; it is not intended to dictate to the developer exactly how to organize/setup your code. For example, the code sample shows modification of main.c in the application /src folder. The developer has the flexibility to organize the code as they see fit so this code does not need to reside in /src/main.c or in the main() function itself. The only possible issue is the order of some of the initializations. Where this order is important it is indicated in the sections covering stack initialization. 
+We are now going to explain how to set up your application to initialize the nimble stack and to get the basic stack, and its required modules, initialized and up and running. Note that the code shown here is an example of what is required for nimble stack operation; it is not intended to dictate to the developer exactly how to organize and set up your code. For example, the code sample shows modification of main.c in the application _/src_ folder. The developer has the flexibility to organize the code as they see fit so this code does not need to reside in _/src/main.c_ or in the _main()_ function itself. The only possible issue is the order of some of the initializations. Where this order is important it is indicated in the sections covering stack initialization.
 
-A note about the code samples: the main() function in each code sample builds upon the previous example. However, code outside of main() shows only what we add for each step. The last code sample shows the entire main.c that we created.
+A note about the code samples: the _main()_ function in each code sample builds upon the previous example. However, code outside of _main()_ shows only what we add for each step. The last code sample shows the entire _main.c_ that we created.
 
-Let's start with a very basic main() function (shown below). In this main all we are doing is initializing the Mynewt OS and starting it.
+Let's start with a very basic _main()_ function (shown below). This _main()_ function is identical to the minimal version used in the [Set up application](../nimble_setup/) introductory page.  In this _main()_ all we are doing is initializing the Mynewt OS and starting it.
 
 ```c
+#include <assert.h>
 #include "os/os.h"
 
 int
@@ -22,7 +23,4 @@ main(void)
     assert(0);
 }
 ```
-The Nimble stack requires a number of packages/modules to be initialized prior to being started. We are going to add these one by one to the application and describe each.
-
-<br>
-
+The Nimble stack requires a number of packages to be initialized prior to being started. We are going to add these one by one to the application and describe each.

--- a/docs/network/ble/nimble_setup.md
+++ b/docs/network/ble/nimble_setup.md
@@ -14,8 +14,8 @@ $ newt new my_proj1
 Downloading project skeleton from apache/incubator-mynewt-blinky...
 Installing skeleton in my_proj1...
 Project my_proj1 successfully created.
-$ tree
-.
+$ tree my_proj1
+my_proj1
 ├── DISCLAIMER
 ├── LICENSE
 ├── NOTICE
@@ -146,17 +146,17 @@ Details of the initialization step requirements are covered in [Initialize Stack
 
 ### Building the application
 
-Now that we have created the application and the target we can build it and test it out. The command you need to run is the newt build command with the target we created (ble\_tgt). The output will show the files being compiled and linked. You should see this when all is done (except for the ... of course):
+Now that we have created the application and the target we can build it and test it out. The command you need to run is the `newt build` command with the target we created (_ble\_tgt_). The output will show the files being compiled and linked. You should see this when all is done (except for the _..._ of course):
 
 ```no-highlight
-wes@~/dev/larva$ newt build ble_tgt
+wes@~/dev/my_proj1$ newt build ble_tgt
 ...
 Archiving os.a
 Compiling cons_fmt.c
 Compiling cons_tty.c
 Archiving full.a
 Linking ble_app.elf
-App successfully built: /Users/wes/dev/larva/bin/ble_tgt/apps/ble_app/ble_app.elf
+App successfully built: /Users/wes/dev/my_proj1/bin/ble_tgt/apps/ble_app/ble_app.elf
 ```
 
 ### Conclusion

--- a/docs/network/ble/nimble_setup.md
+++ b/docs/network/ble/nimble_setup.md
@@ -114,22 +114,22 @@ The target is not yet complete though! We need to set some target variables for 
 Here is the command you will need to set up your target for the nrf52:
 
 ```no-highlight
-$ newt target set ble_tgt app=apps/ble_app          \
-                          bsp=hw/bsp/nrf52pdk       \
+$ newt target set ble_tgt app=apps/ble_app                              \
+                          bsp=@apache-mynewt-core/hw/bsp/nrf52pdk       \
                           build_profile=optimized
 Target targets/ble_tgt successfully set target.app to apps/ble_app
-Target targets/ble_tgt successfully set target.bsp to hw/bsp/nrf52pdk
+Target targets/ble_tgt successfully set target.bsp to @apache-mynewt-core/hw/bsp/nrf52pdk
 Target targets/ble_tgt successfully set target.build_profile to optimized
 ```
 
 Here is the command you will need to set up your target for the nrf51:
 
 ```no-highlight
-$ newt target set ble_tgt app=apps/ble_app          \
-                          bsp=hw/bsp/nrf51dk        \
+$ newt target set ble_tgt app=apps/ble_app                              \
+                          bsp=@apache-mynewt-core/hw/bsp/nrf51dk        \
                           build_profile=optimized
 Target targets/ble_tgt successfully set target.app to apps/ble_app
-Target targets/ble_tgt successfully set target.bsp to hw/bsp/nrf51dk
+Target targets/ble_tgt successfully set target.bsp to @apache-mynewt-core/hw/bsp/nrf51dk
 Target targets/ble_tgt successfully set target.build_profile to optimized
 ```
 

--- a/docs/network/ble/nimble_setup.md
+++ b/docs/network/ble/nimble_setup.md
@@ -10,11 +10,11 @@ This tutorial assumes that you have already installed the newt tool and are fami
 You start by creating a project space for your own application work using the Newt tool (`my_proj1` in this example) and installing all the additional apps and libraries available by adding the repo `apache-mynewt-core`. See the tutorial on [adding a repo](../../os/tutorials/add_repos.md) for more on working with repos.
 
 ```
-$ newt new my_proj1
+~/dev$ newt new my_proj1
 Downloading project skeleton from apache/incubator-mynewt-blinky...
 Installing skeleton in my_proj1...
 Project my_proj1 successfully created.
-$ tree my_proj1
+~/dev$ tree my_proj1
 my_proj1
 ├── DISCLAIMER
 ├── LICENSE
@@ -36,10 +36,10 @@ my_proj1
 
 6 directories, 11 files
     
-$ cd my_proj1
-$ newt install
+~/dev$ cd my_proj1
+~/dev/my_proj1$ newt install
 apache-mynewt-core
-$ tree 
+~/dev/my_proj1$ tree
 .
 ├── DISCLAIMER
 ├── LICENSE
@@ -87,14 +87,53 @@ $ tree
 It's time to build your own app using one or more of the example apps available in the repo `apache-mynewt-core`. 
 
 ```
-$ ls repos/apache-mynewt-core/apps
+~/dev/my_proj1$ ls repos/apache-mynewt-core/apps
 bleprph		bletiny		boot		luatest		test
 bletest		blinky		ffs2native	slinky
 ```
 
 <br>
 
-At the very least your app must contain a `main.c()` and a `pkg.yml` file. So copy the ones from `bletiny` and start enhancing it for your own custom use case!
+At the very least your app must contain a `main()` function and a `pkg.yml` file.  Use the following steps to create minimal ...
+
+*1. Create the app directory structure.*
+```no-highlight
+~/dev/my_proj1$ mkdir -p apps/ble_app/src
+```
+<br>
+*2. Paste the following contents into `apps/ble_app/pkg.yml`.*
+
+```no-highlight
+pkg.name: apps/ble_app
+pkg.type: app
+
+pkg.deps:
+    - "@apache-mynewt-core/libs/baselibc"
+    - "@apache-mynewt-core/libs/console/full"
+    - "@apache-mynewt-core/libs/os"
+    - "@apache-mynewt-core/net/nimble/controller"
+    - "@apache-mynewt-core/net/nimble/host"
+```
+<br>
+*3. Paste the following contents into `apps/ble_app/src/main.c`.*
+```c
+#include <assert.h>
+#include "os/os.h"
+
+int
+main(void)
+{
+    /* Initialize OS */
+    os_init();
+
+    /* Start the OS */
+    os_start();
+
+    /* os_start should never return. If it does, this should be an error */
+    assert(0);
+}
+```
+In this _main()_ all we are doing is initializing the Mynewt OS and starting it.
 
 <br>
 
@@ -103,7 +142,7 @@ At the very least your app must contain a `main.c()` and a `pkg.yml` file. So co
 Now you have to create the target that you will use to build your application. We will call this target "ble\_tgt". Type the `newt target create ble_tgt` command. You should get this:
 
 ```no-highlight
-$ newt target create ble_tgt
+~/dev/my_proj1$ newt target create ble_tgt
 Target targets/ble_tgt successfully created
 ```
 
@@ -114,9 +153,10 @@ The target is not yet complete though! We need to set some target variables for 
 Here is the command you will need to set up your target for the nrf52:
 
 ```no-highlight
-$ newt target set ble_tgt app=apps/ble_app                              \
-                          bsp=@apache-mynewt-core/hw/bsp/nrf52pdk       \
-                          build_profile=optimized
+~/dev/my_proj1$ newt target set ble_tgt     \
+    app=apps/ble_app                        \
+    bsp=@apache-mynewt-core/hw/bsp/nrf52pdk \
+    build_profile=optimized
 Target targets/ble_tgt successfully set target.app to apps/ble_app
 Target targets/ble_tgt successfully set target.bsp to @apache-mynewt-core/hw/bsp/nrf52pdk
 Target targets/ble_tgt successfully set target.build_profile to optimized
@@ -125,16 +165,16 @@ Target targets/ble_tgt successfully set target.build_profile to optimized
 Here is the command you will need to set up your target for the nrf51:
 
 ```no-highlight
-$ newt target set ble_tgt app=apps/ble_app                              \
-                          bsp=@apache-mynewt-core/hw/bsp/nrf51dk        \
-                          build_profile=optimized
+~/dev/my_proj1$ newt target set ble_tgt     \
+    app=apps/ble_app                        \
+    bsp=@apache-mynewt-core/hw/bsp/nrf51dk  \
+    build_profile=optimized
 Target targets/ble_tgt successfully set target.app to apps/ble_app
 Target targets/ble_tgt successfully set target.bsp to @apache-mynewt-core/hw/bsp/nrf51dk
 Target targets/ble_tgt successfully set target.build_profile to optimized
 ```
 
 <br>
-
 
 ### Nimble stack initialization
 
@@ -149,7 +189,7 @@ Details of the initialization step requirements are covered in [Initialize Stack
 Now that we have created the application and the target we can build it and test it out. The command you need to run is the `newt build` command with the target we created (_ble\_tgt_). The output will show the files being compiled and linked. You should see this when all is done (except for the _..._ of course):
 
 ```no-highlight
-wes@~/dev/my_proj1$ newt build ble_tgt
+~/dev/my_proj1$ newt build ble_tgt
 ...
 Archiving os.a
 Compiling cons_fmt.c

--- a/docs/network/ble/nimble_setup.md
+++ b/docs/network/ble/nimble_setup.md
@@ -1,6 +1,6 @@
 ## Set up a NimBLE application
 
-This tutorial explains how to setup an application using the NimBLE stack. The end result will be a framework that you can use to create your own BLE application using the nimble stack.
+This tutorial explains how to set up an application using the NimBLE stack. The end result will be a framework that you can use to create your own BLE application using the nimble stack.
 
 This tutorial assumes that you have already installed the newt tool and are familiar with its concepts.
 
@@ -94,7 +94,7 @@ bletest		blinky		ffs2native	slinky
 
 <br>
 
-At the very least your app must contain a `main.c()` and a `pkg.yml` file. So copy the ones from `bletiny`. And start enhancing it for your own custom use case!
+At the very least your app must contain a `main.c()` and a `pkg.yml` file. So copy the ones from `bletiny` and start enhancing it for your own custom use case!
 
 <br>
 
@@ -111,7 +111,7 @@ What this command just did was to create a directory called `ble_tgt` in the tar
 
 The target is not yet complete though! We need to set some target variables for this project. Currently, the nimble stack has been ported to the Nordic nrf5x chipsets; specifically the nrf51 and nrf52. This application will use the nrf52 but we will also show the setup for the nrf51 in case your project uses that chip.
 
-Here is the command you will need to setup your target for the nrf52:
+Here is the command you will need to set up your target for the nrf52:
 
 ```no-highlight
 $ newt target set ble_tgt app=apps/ble_app          \
@@ -122,7 +122,7 @@ Target targets/ble_tgt successfully set target.bsp to hw/bsp/nrf52pdk
 Target targets/ble_tgt successfully set target.build_profile to optimized
 ```
 
-Here is the command you will need to setup your target for the nrf51:
+Here is the command you will need to set up your target for the nrf51:
 
 ```no-highlight
 $ newt target set ble_tgt app=apps/ble_app          \
@@ -140,7 +140,7 @@ Target targets/ble_tgt successfully set target.build_profile to optimized
 
 There are certain stack initialization steps that are required for a BLE application to be up and running. If you are running a canned example (e.g. bletiny), these steps are already done for you. When you are writing your own app, you may want to assign different initial values or initialize additional packages that you may have added to your project or written yourself. 
 
-Details of the initialization step requirements are covered in the section on how to [Initialize Stack](ini_stack/ble_ini_intro.md).
+Details of the initialization step requirements are covered in [Initialize Stack](ini_stack/ble_ini_intro.md) step.
 
 <br>
 

--- a/docs/network/ble/nimble_setup.md
+++ b/docs/network/ble/nimble_setup.md
@@ -7,13 +7,13 @@ This tutorial assumes that you have already installed the newt tool and are fami
 
 ### Create the application directory
 
-You start by creating a project space for your own application work using the Newt tool (`my_app1` in this example) and installing all the additional apps and libraries available by adding the repo `apache-mynewt-core`. See the tutorial on [adding a repo](../../os/tutorials/add_repos.md) for more on working with repos.
+You start by creating a project space for your own application work using the Newt tool (`my_proj1` in this example) and installing all the additional apps and libraries available by adding the repo `apache-mynewt-core`. See the tutorial on [adding a repo](../../os/tutorials/add_repos.md) for more on working with repos.
 
 ```
-$ newt new my_app1
+$ newt new my_proj1
 Downloading project skeleton from apache/incubator-mynewt-blinky...
-Installing skeleton in my_app1...
-Project my_app1 successfully created.
+Installing skeleton in my_proj1...
+Project my_proj1 successfully created.
 $ tree
 .
 ├── DISCLAIMER
@@ -36,7 +36,7 @@ $ tree
 
 6 directories, 11 files
     
-$ cd my_app1
+$ cd my_proj1
 $ newt install
 apache-mynewt-core
 $ tree 


### PR DESCRIPTION
I noticed some issues with the BLE user guide:
* Some of the steps assumed the user was building from the core directory rather than from their project directory.
* Copying bletiny's pkg.yml and main.c files is problematic; the files need to be customized for the new app.
* Some minor grammar / typo fixes.