### PR TITLE
Remove rogue space in stats documentation

### DIFF
--- a/docs/os/modules/stats/stats.md
+++ b/docs/os/modules/stats/stats.md
@@ -44,7 +44,7 @@ struct stats_hdr {
  #endif
      STAILQ_ENTRY(stats_hdr) s_next;
  };
- ```
+```
  
  <br>
  


### PR DESCRIPTION
An extra space before the closing triple-quotes for the first code block seems
to cause the clode block to not be closed and the rest of the page is messed
up. This is a difference between the Markdown renderer on Github and the Mkdocs
renderer used to create the documentation on the website.

Signed-off-by: Sam Bristow <sam.bristow@gmail.com>