### PR TITLE
Fix file ownership on linux

### DIFF
--- a/docs/os/get_started/docker.md
+++ b/docs/os/get_started/docker.md
@@ -25,7 +25,7 @@ Use the newt wrapper script to invoke newt.  Create the following file, name it
 ```bash
 #!/bin/bash
 
-docker run -ti --rm --device=/dev/bus/usb --privileged -v $(pwd):/workspace -w /workspace mynewt/newt:latest /newt "$@"
+docker run -e NEWT_USER=$(id -u) -e NEWT_GROUP=$(id -g) -e NEWT_HOST=$(uname) -ti --rm --device=/dev/bus/usb --privileged -v $(pwd):/workspace -w /workspace mynewt/newt:latest /newt "$@"
 ```
 
 <br>


### PR DESCRIPTION
Pass the current user and group so the container creates files with the
correct ownership on Linux.