### PR TITLE
Update PPA for Linux toolchain

### DIFF
--- a/docs/newt/install/newt_linux.md
+++ b/docs/newt/install/newt_linux.md
@@ -13,6 +13,8 @@ If you want to build the *newt* tool from its source code, follow the following 
         $ sudo apt-get install libcurl4-gnutls-dev 
 ```
 
+**NOTE:** On 64-bit host, you may also need to install gcc-multilib, if you encounter compilation errors related to 'sys/cdefs.h'
+
 <br>
 
 #### 2. Install Go, the programming language

--- a/docs/os/get_started/cross_tools.md
+++ b/docs/os/get_started/cross_tools.md
@@ -58,11 +58,11 @@ lrwxr-xr-x  1 <user>  admin  36 Sep 17 16:22 /usr/local/bin/openocd -> ../Cellar
 
 On a Debian-based Linux distribution, gcc 4.9.3 for ARM can be installed with
 apt-get as documented below. The steps are explained in depth at
-[https://launchpad.net/~terry.guo/+archive/ubuntu/gcc-arm-embedded](https://launchpad.net/~terry.guo/+archive/ubuntu/gcc-arm-embedded).
+[https://launchpad.net/~team-gcc-arm-embedded/+archive/ubuntu/ppa](https://launchpad.net/~team-gcc-arm-embedded/+archive/ubuntu/ppa).
 
 ```no-highlight
 $ sudo apt-get remove binutils-arm-none-eabi gcc-arm-none-eabi 
-$ sudo add-apt-repository ppa:terry.guo/gcc-arm-embedded 
+$ sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa
 $ sudo apt-get update 
 $ sudo apt-get install gcc-arm-none-eabi
 $ sudo apt-get install gdb-arm-none-eabi


### PR DESCRIPTION
The old terry.guo PPA is no longer maintained, and replaced by team maintained one, see

https://launchpad.net/gcc-arm-embedded/+announcement/13824
