### PR TITLE
Updated Enabling Newt Manager Tutorial and Image Manager to reflect new Newt Manager Implementation

### DIFF
--- a/docs/os/modules/devmgmt/customize_newtmgr.md
+++ b/docs/os/modules/devmgmt/customize_newtmgr.md
@@ -1,0 +1,55 @@
+## Customizing Newt Manager Usage with mgmt
+
+The **mgmt** package enables you to customize Newt Manager (in either the newtmgr or oicmgr framerwork) to only process the
+commands that your application uses. The newtmgr commands are divided into management groups.
+A manager package implements the commands for a group.  It implements the handlers that 
+process the commands for the group and registers the handlers with mgmt. 
+When newtmgr or oicmgr receives a newtmgr command, 
+it looks up the handler for the command (by management group id and command id) from mgmt and calls the 
+handler to process the command.   
+
+The system level management groups are listed in following table:
+<table style="width:90%" align="center">
+<tt>
+<td>Management Group</td>
+<td>newtmgr Commands</td>
+<td>Package</td>
+</tt>
+<tr>
+<td>MGMT_GROUP_ID_DEFAULT</td>
+<td>```echo``` ```taskstats``` ```mpstats``` ```datetime``` ```reset```</td>
+<td>mgmt/newtmgr/nmgr_os</td>
+</tr>
+<tr>
+<td>MGMT_GROUP_ID_IMAGE</td>
+<td>```image``` </td>
+<td>mgmt/imgmgr</td>
+</tr>
+<tr>
+<td>MGMT_GROUP_ID_STATS</td>
+<td>```stat``` </td>
+<td>sys/stats</td>
+</tr>
+<tr>
+<td>MGMT_GROUP_ID_CONFIG</td>
+<td>```config```</td>
+<td>sys/config</td>
+</tr>
+<tr>
+<td>MGMT_GROUP_ID_LOGS</td>
+<td>```log```</td>
+<td>sys/log</td>
+</tr>
+<tr>
+<td>MGMT_GROUP_ID_CRASH</td>
+<td>```crash```</td>
+<td>test/crash_test</td>
+</tr>
+<tr>
+<td>MGMT_GROUP_ID_RUNTEST</td>
+<td>```run```</td>
+<td>test/runtest</td>
+</tr>
+</table>
+Both newtmgr and ocimgr process the MGMT_GROUP_ID_DEFAULT commands by default.  You can also
+use mgmt to add user defined management group commands. 

--- a/docs/os/modules/devmgmt/oicmgr.md
+++ b/docs/os/modules/devmgmt/oicmgr.md
@@ -1,4 +1,4 @@
-## Using the OIC framework
+## Using the OIC Framework
 
 Apache Mynewt includes support for the OIC interoperability standard through the `oicmgr` framework.  Mynewt defines and exposes oicmgr as an OIC Server resource with the following identity and properties: 
 <br>
@@ -29,59 +29,3 @@ for example, the ```echo``` or ```datetime``` commands.
 * Sends the CBOR-encoded command request data in the CoAP message payload.
 
 The `oicmgr` framework supports transport over BLE, serial, and IP connections to the device.
-
-### Customize Newt Manager usage with mgmt
-
-The **mgmt** package enables you to customize Newt Manager (in either the newtmgr or oicmgr framerwork) to only process the
-commands that your application uses. The newtmgr commands are divided into management groups.
-A manager package implements the commands for a group.  It implements the handlers that 
-process the commands for the group and registers the handlers with mgmt. 
-When newtmgr or oicmgr receives a newtmgr command, 
-it looks up the handler for the command (by management group id and command id) from mgmt and calls the 
-handler to process the command.   
-
-The system level management groups are listed in following table:
-<table style="width:90%" align="center">
-<tt>
-<td>Management Group</td>
-<td>newtmgr Commands</td>
-<td>Package</td>
-</tt>
-<tr>
-<td>MGMT_GROUP_ID_DEFAULT</td>
-<td>```echo``` ```taskstats``` ```mpstats``` ```datetime``` ```reset```</td>
-<td>mgmt/newtmgr/nmgr_os</td>
-</tr>
-<tr>
-<td>MGMT_GROUP_ID_IMAGE</td>
-<td>```image``` </td>
-<td>mgmt/imgmgr</td>
-</tr>
-<tr>
-<td>MGMT_GROUP_ID_STATS</td>
-<td>```stat``` </td>
-<td>sys/stats</td>
-</tr>
-<tr>
-<td>MGMT_GROUP_ID_CONFIG</td>
-<td>```config```</td>
-<td>sys/config</td>
-</tr>
-<tr>
-<td>MGMT_GROUP_ID_LOGS</td>
-<td>```log```</td>
-<td>sys/log</td>
-</tr>
-<tr>
-<td>MGMT_GROUP_ID_CRASH</td>
-<td>```crash```</td>
-<td>test/crash_test</td>
-</tr>
-<tr>
-<td>MGMT_GROUP_ID_RUNTEST</td>
-<td>```runtest```</td>
-<td>test/runtest</td>
-</tr>
-</table>
-Both newtmgr and ocimgr process the MGMT_GROUP_ID_DEFAULT commands by default.  You can also
-use mgmt to add user defined management group commands. 

--- a/docs/os/modules/imgmgr/imgmgr_module_init.md
+++ b/docs/os/modules/imgmgr/imgmgr_module_init.md
@@ -1,36 +1,19 @@
 ## <font color="#F2853F" style="font-size:24pt"> imgmgr_module_init </font>
 
 ```no-highlight
-   int
+   void 
    imgmgr_module_init(void)
 ```
 
-  Registers image manager commands with newtmgr. This function should be called while initializing the project, preferably after newtmgr itself has been initialized.
+Registers the image manager commands with the `mgmt` package.  `sysinit()` automatically calls this function during
+system initialization.
 
 #### Arguments
 
 N/A
 
 #### Returned values
-
-List any values returned.
-Error codes?
+N/A
 
 #### Notes
-
-
-#### Example
-
-```no-highlight
-int main(int argc, char **argv)
-{
-    ...
-    
-    nmgr_task_init(NEWTMGR_TASK_PRIO, newtmgr_stack, NEWTMGR_TASK_STACK_SIZE);
-    imgmgr_module_init();
-
-    ...
-}
-```
-
 

--- a/docs/os/tutorials/add_newtmgr.md
+++ b/docs/os/tutorials/add_newtmgr.md
@@ -20,7 +20,7 @@ See [Other Configuration Options](#other-configuration-options) on how to custom
 
 <br>
 
-### Pre-Requisites
+### Prerequisites
 Ensure that you have met the following prerequisites before continuing with this tutorial:
 
 * Installed the [newt tool](../../newt/install/newt_mac.md). 
@@ -28,7 +28,6 @@ Ensure that you have met the following prerequisites before continuing with this
 * Have Internet connectivity to fetch remote Mynewt components.
 * Installed the [compiler tools](../get_started/native_tools.md) to 
 support native compiling to build the project this tutorial creates.  
-* Installed the [Segger JLINK package]( https://www.segger.com/jlink-software.html) to load your project on the board.
 * Have a cable to establish a serial USB connection between the board and the laptop.
 
 <br>
@@ -267,5 +266,6 @@ Notes:
 * When you enable Newt Manager support, using either the newtmgr or oicmgr framework, your application automatically 
 supports the Newt Manager `echo`, `taskstats`, `mpstats`, `datetime`, and `reset` commands.  These 
 commands cannot be configured individually.
-* Currently, the `mgmt/imgmgr` package does not provide a configuration setting to enable or disable support 
-for the `newtmgr image` command. 
+* The `mgmt/imgmgr` package does not provide a configuration setting to enable or disable support 
+for the `newtmgr image` command.  Do not specify the package in the `pkg.deps` parameter if 
+your device has limited flash memory and cannot support Over-The-Air (OTA) firmware upgrades.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,7 +52,7 @@ pages:
         - 'Project Slinky for remote comms':
             - 'Slinky on sim device': 'os/tutorials/project-slinky.md'
             - 'Slinky on STM32 board': 'os/tutorials/project-target-slinky.md'
-        - 'Enable newtmgr in any app': 'os/tutorials/add_newtmgr.md' 
+        - 'Enable Newt Manager in any app': 'os/tutorials/add_newtmgr.md' 
         - 'Enable the OS Shell and Console': 'os/tutorials/add_shell.md'
         - 'BLE app to check stats via console': 'os/tutorials/bletiny_project.md'
         - 'BLE peripheral project':
@@ -314,6 +314,7 @@ pages:
         - Device Management with Newt Manager: 
             - toc: 'os/modules/devmgmt/newtmgr.md'
             - 'Using Newt Manager in OIC framework': 'os/modules/devmgmt/oicmgr.md'
+            - 'Customizing Newt Manager Usage with mgmt': 'os/modules/devmgmt/customize_newtmgr.md'
         - Image Manager:
             - toc: 'os/modules/imgmgr/imgmgr.md'
             - 'Functions':


### PR DESCRIPTION
1) Updated Enabling Newt Manager" tutorial to reflect current implmentation (i.e no need to create
designated task etc)
2) Added information on how to configure an application with other Newt Manager options, such
as oicmgr etc.
3) Updated the imgmgr_module_init so that it doesn't show example to create a dedicated task
for newtmgr. Mentioned that the function is called by sysinit().
4) Minor cleanup to  the Device Management Using Newt Manager section. Moved the Customizing
section to a separate page.