### PR TITLE
mfg docs - slight rewording / rearranging

### DIFF
--- a/docs/newt/command_list/newt_mfg.md
+++ b/docs/newt/command_list/newt_mfg.md
@@ -60,21 +60,13 @@ targets/rb_boot
     build_profile=optimized
 ```
 
-Build the bootloader and app images.
-
-```
-$ newt build rb_boot
-$ newt build rb_boot
-$ newt create-image rb_blinky 0.0.1
-```
-
-Create the directory and package to hold the manufacturing images.
+Create the directory and to hold the mfg packages.
 
 ```
 $ mkdir -p mfgs/rb_blinky_rsa
 ```
 
-The `rb_blinky_rsa` package needs a pkg.yml file. In addition it is needs a mfg.yml file where the two constituent targets are defined. An example of each file is shown below.
+The `rb_blinky_rsa` package needs a pkg.yml file. In addition it is needs a mfg.yml file to specify the two constituent targets. An example of each file is shown below.
 
 ```
 $  more mfgs/rb_blinky_rsa/pkg.yml 
@@ -90,6 +82,13 @@ $  more mfgs/rb_blinky_rsa/mfg.yml
 mfg.bootloader: 'targets/rb_boot'
 mfg.images:
     - 'targets/rb_blinky'
+```
+
+Build the bootloader and app images.
+
+```
+$ newt build rb_boot
+$ newt create-image rb_blinky 0.0.1
 ```
 
 Run the `newt mfg create` command to collect all the manufacturing snapshot files.


### PR DESCRIPTION
1. Move create mfg step such that it comes before the boot-build and
create-image steps.

Rationale: The mfg package only needs to be created once, whereas the
boot loader and image need to be rebuilt each time a new mfg image is
built.  It makes sense to group the steps that need to be repeated
together.

2. Remove redundant 'newt build rb_boot' line from example

This line was accidentally duplicated.

3. Slight rewording of some text to keep vocabulary consistent (mfg
package versus manufacturing image).