### PR TITLE
Fix minor typos in the newtmgr conn add and newtmgr crash commands

### DIFF
--- a/docs/newtmgr/command_list/newtmgr_conn.md
+++ b/docs/newtmgr/command_list/newtmgr_conn.md
@@ -21,7 +21,7 @@ The conn command provides subcommands to add, delete, and view configuration pro
 
 Sub-command  | Explanation
 -------------| ------------------------
-add       | The newtmgr conn add <conn_profile> <var-name=var-value> command creates a connection profile named `conn_profile`. A profile consists of these variables: <ul><li>`name`: Connection name. Defaults to `conn_profile` when the variable is not set in the command. </li><li>`type`: Connection type. Valid types are: `serial`, `oic_serial`, `ble`, `oic_ble`, `udp`, `oic_udp`.</li><li>`connstring`: The physical or virtual port to use for the connection.</li><li>`addrtype`: Device address type. Use with type `ble`.</li><li>`addr`:  Device address. Use with type `ble`.</ul>
+add       | The newtmgr conn add &lt;conn_profile&gt; &lt;var-name=var-value...&gt; command creates a connection profile named `conn_profile`. A profile consists of these variables: <ul><li>`name`: Connection name. Defaults to `conn_profile` when the variable is not set in the command. </li><li>`type`: Connection type. Valid types are: `serial`, `oic_serial`, `ble`, `oic_ble`, `udp`, `oic_udp`.</li><li>`connstring`: The physical or virtual port to use for the connection.</li><li>`addrtype`: Device address type. Use with type `ble`.</li><li>`addr`:  Device address. Use with type `ble`.</ul>
 delete    | The newtmgr conn delete &lt;conn_profile&gt; command deletes the `conn_profile` connection profile.
 show      | The newtmgr conn show [conn_profile] command shows the information for the `conn_profile` connection profile. It shows information for all the connection profiles if `conn_profile` is not specified.
     

--- a/docs/newtmgr/command_list/newtmgr_crash.md
+++ b/docs/newtmgr/command_list/newtmgr_crash.md
@@ -5,7 +5,7 @@ Send a crash command to a device.
 #### Usage:
 
 ```no-highlight
-    newtmgr crash <div0|jump0|ref0|assert|wdog> -c <conn_profile>; [flags] 
+    newtmgr crash <div0|jump0|ref0|assert|wdog> -c <conn_profile> [flags] 
 ```
 
 #### Global Flags:


### PR DESCRIPTION
1) Fixed problem with  `newtmgr conn add` command parameters not showing  up in the document. Use `&lt;` and `&gt;` instead of `< `and `>`.
2) Removed extra `;` in the `newtmgr crash` command usage text.