### PR TITLE
Various Updates to Doc to reflect 1.0 release

### DIFF
--- a/docs/os/core_os/context_switch/context_switch.md
+++ b/docs/os/core_os/context_switch/context_switch.md
@@ -36,6 +36,7 @@ The functions available in context_switch are:
 | [os_sched_insert](os_sched_insert.md) | Insert a task into scheduler's *ready to run* list. |
 | [os_sched_next_task](os_sched_next_task.md) | Returns the pointer to highest priority task from the list which are *ready to run*. |
 | [os_sched_os_timer_exp](os_sched_os_timer_exp.md) | Inform scheduler that OS time has moved forward. |
+| [os_sched_remove](os_sched_remove.md) | Stops a task and removes it from all the OS task lists. |
 | [os_sched_resort](os_sched_resort.md) | Inform scheduler that the priority of the given task has changed and the *ready to run* list should be re-sorted. |
 | [os_sched_set_current_task](os_sched_set_current_task.md) | Sets the given task to *running*. |
 | [os_sched_sleep](os_sched_sleep.md) | The given task's state is changed from *ready to run* to *sleeping*. |

--- a/docs/os/core_os/context_switch/os_sched_remove.md
+++ b/docs/os/core_os/context_switch/os_sched_remove.md
@@ -1,0 +1,45 @@
+## <font color="#F2853F" style="font-size:24pt"> os_sched_remove </font>
+
+```c
+int os_sched_remove(struct os_task *t)
+```
+Stops and removes task `t`.
+
+The function removes the task from the `g_os_task_list` task list. It also removes the task from one of the following task list:
+
+* `g_os_run_list` if the task is in the Ready state.
+* `g_os_sleep_list` if the task is in the Sleep state.
+
+#### Arguments
+
+| Arguments | Description |
+|-----------|-------------|
+| `t` | Pointer to the `os_task` structure for the task to be removed.|
+
+#### Returned values
+OS_OK - The task is removed successfully.
+
+#### Notes
+This function must be called with all interrupts disabled.
+
+#### Example
+
+The `os_task_remove` function calls the `os_sched_remove ` function to remove a task:
+```c
+
+int
+os_task_remove(struct os_task *t)
+{
+    int rc;
+    os_sr_t sr;
+
+    /* Add error checking code to ensure task can removed. */
+  
+
+    /* Call os_sched_remove to remove the task. */
+    OS_ENTER_CRITICAL(sr);
+    rc = os_sched_remove(t);
+    OS_EXIT_CRITICAL(sr);
+    return rc;
+}
+```

--- a/docs/os/core_os/memory_pool/memory_pool.md
+++ b/docs/os/core_os/memory_pool/memory_pool.md
@@ -42,11 +42,21 @@ struct os_mempool {
     int mp_block_size;
     int mp_num_blocks;
     int mp_num_free;
+    int mp_min_free;
     uint32_t mp_membuf_addr;
     STAILQ_ENTRY(os_mempool) mp_list;    
     SLIST_HEAD(,os_memblock);
     char *name;
 };
+
+struct os_mempool_info {
+    int omi_block_size;
+    int omi_num_blocks;
+    int omi_num_free;
+    int omi_min_free;
+    char omi_name[OS_MEMPOOL_INFO_NAME_LEN];
+};
+
 ```
 <br>
 
@@ -55,6 +65,7 @@ struct os_mempool {
 | mp_block_size | Size of the memory blocks, in bytes. This is not the actual  number of bytes used by each block; it is the requested size of each block. The actual memory block size will be aligned to OS_ALIGNMENT bytes |
 | mp_num_blocks | Number of memory blocks in the pool |
 | mp_num_free | Number of free blocks left |
+| mp_min_free | Lowest number of free blocks seen |
 | mp_membuf_addr | The address of the memory block. This is used to check that a valid memory block is being freed. |
 | mp_list | List pointer to chain memory pools so they can be displayed by newt tools |
 | SLIST_HEAD(,os_memblock) | List pointer to chain free memory blocks |
@@ -70,6 +81,7 @@ The functions/macros available in mem_pool are:
 | [os_memblock_get](os_memblock_get) | Allocate an element from the memory pool. |
 | [os_mempool_init](os_mempool_init) | Initializes the memory pool. |
 | [os_memblock_put](os_memblock_put) | Releases previously allocated element back to the pool. |
+| [os_mempool_info_get_next](os_mempool_info_get_next) | Retrieves memory pool information for the next memory pool. |
 | [OS_MEMPOOL_BYTES](OS_MEMPOOL_BYTES) | Calculates how many bytes of memory is used by n number of elements, when individual element size is blksize bytes. |
 | [OS_MEMPOOL_SIZE](OS_MEMPOOL_SIZE) | Calculates the number of os_membuf_t elements used by n blocks of size blksize bytes. |
 

--- a/docs/os/core_os/memory_pool/os_mempool_info_get_next.md
+++ b/docs/os/core_os/memory_pool/os_mempool_info_get_next.md
@@ -1,0 +1,70 @@
+## <font color="F2853F" style="font-size:24pt"> os_mempool_info_get_next</font>
+
+```c
+struct os_mempool * os_mempool_info_get_next(struct os_mempool *mp, struct os_mempool_info *omi)
+```
+Populates the os_mempool_info structure pointed to by `omi` with memory pool information. 
+The value of `mp` specifies the memory pool information to populate. If `mp` is **NULL**, it populates the information for the first memory pool on the memory pool list. If `mp` is not NULL, it populates the information for the next memory pool after `mp`.   
+ 
+<br>
+#### Arguments
+
+| Arguments | Description | 
+|-----------|-------------| 
+| `mp` | Pointer to the memory pool in the memory pool list from the previous `os_mempool_info_get_next` function call. The next memory pool after `mp` is populated. If `mp` is NULL, the first memory pool on the memory pool list is populated.|
+| `omi` |  Pointer to `os_mempool_info` structure where memory information will be stored.| 
+
+<br>
+#### Returned values
+
+* A pointer to the memory pool structure that was used to populate the memory pool information structure. 
+
+* NULL indicates `mp` is the last memory pool on the list and `omi` is not populated with memory pool information.
+
+<br>
+#### Example
+
+```c
+
+shell_os_mpool_display_cmd(int argc, char **argv)
+{
+    struct os_mempool *mp;
+    struct os_mempool_info omi;
+    char *name;
+
+    name = NULL;
+    found = 0;
+
+    if (argc > 1 && strcmp(argv[1], "")) {
+        name = argv[1];                  
+    }
+    console_printf("Mempools: \n");
+    mp = NULL;
+    console_printf("%32s %5s %4s %4s %4s\n", "name", "blksz", "cnt", "free",
+                   "min");
+    while (1) {
+        mp = o{_mempool_info_get_next(mp, &omi);
+        if (mp == NULL) {
+            break;      
+        }
+        if (name) {
+            if (strcmp(name, omi.omi_name)) {
+                continue;
+            } else {
+                found = 1;
+            }
+        }
+
+        console_printf("%32s %5d %4d %4d %4d\n", omi.omi_name,
+                       omi.omi_block_size, omi.omi_num_blocks,
+                       omi.omi_num_free, omi.omi_min_free);
+    }
+
+    if (name && !found) {
+        console_printf("Couldn't find a memory pool with name %s\n",
+                name);
+    }
+    return (0);
+}
+
+```

--- a/docs/os/core_os/task/os_task_remove.md
+++ b/docs/os/core_os/task/os_task_remove.md
@@ -1,0 +1,43 @@
+## <font color="F2853F" style="font-size:24pt"> os_task_remove</font>
+
+```c
+int os_task_remove(struct os_task *t)
+```
+Removes a task, `t`, from the task list. A task cannot be removed when it is in one of the following states:
+
+* It is running - a task cannot remove itself.
+* It has not been initialized.
+* It is holding a lock on a semphore or mutex.
+* It is suspended waiting on a lock (semaphore or mutex) or for an event on an event queue.
+
+<br>
+#### Arguments
+
+| Arguments | Description | 
+|-----------|-------------| 
+| `t` | Pointer to the `os_task` structure for the task to be removed |
+
+<br>
+#### Returned values
+`OS_OK`:  Task `t` is removed sucessfully.
+<br>`OS_INVALID_PARM`:  Task `t` is the calling task. A task cannot remove itself.
+<br>`OS_NOT_STARTED`:  Task `t` is not initialized.
+<br>`OS_EBUSY`: Task `t` is either holding a lock or suspended waiting on lock on event.
+<br>
+#### Example
+
+```c
+
+struct os_task worker_task;
+
+int
+remove_my_worker_task(void)
+{
+    /* Add error checking code to ensure task can removed. */
+    
+    /* Call os_task_remove to remove the worker task */
+    rc = os_task_remove(&worker_task);
+    return rc;
+}
+```
+

--- a/docs/os/core_os/task/task.md
+++ b/docs/os/core_os/task/task.md
@@ -223,3 +223,4 @@ The functions available in task are:
 | [os_task_init](os_task_init.md) | Called to create a task. This adds the task object to the list of ready to run tasks. |
 | [os_task_count](os_task_count.md) | Returns the number of tasks that have been created. |
 | [os_task_info_get_next](os_task_info_get_next.md) | Populates the os task info structure given with task information. |
+| [os_task_remove](os_task_remove.md)| Removes a task from the task list.| 

--- a/docs/os/get_started/project_create.md
+++ b/docs/os/get_started/project_create.md
@@ -85,12 +85,11 @@ file.
 ```no-highlight
 repository.apache-mynewt-core:
     type: github
-    vers: 0-latest
+    vers: 1-latest
     user: apache
     repo: incubator-mynewt-core
 ```
-Changing to 0-dev will put you on the develop branch. **The Develop Branch may not be stable and 
-you may encounter bugs or other problems.**
+Changing to 1-dev will put you on the develop branch. **The Develop Branch may not be stable and you may encounter bugs or other problems.**
 
 <br>
 
@@ -115,7 +114,7 @@ Once _newt install_ has successfully finished, the contents of _apache-mynewt-co
 
 ```no-highlight
 $ tree -L 2 repos/apache-mynewt-core/
-repos/apache-mynewt-core/
+
 repos/apache-mynewt-core/
 ├── CODING_STANDARDS.md
 ├── DISCLAIMER
@@ -128,10 +127,12 @@ repos/apache-mynewt-core/
 │   ├── blehci
 │   ├── bleprph
 │   ├── bleprph_oic
+│   ├── blesplit
 │   ├── bletest
 │   ├── bletiny
 │   ├── bleuart
 │   ├── boot
+│   ├── fat2native
 │   ├── ffs2native
 │   ├── ocf_sample
 │   ├── slinky
@@ -139,16 +140,20 @@ repos/apache-mynewt-core/
 │   ├── spitest
 │   ├── splitty
 │   ├── test
+│   ├── testbench
 │   └── timtest
 ├── boot
 │   ├── boot_serial
 │   ├── bootutil
-│   └── split
+│   ├── split
+│   └── split_app
 ├── compiler
 │   ├── arm-none-eabi-m0
 │   ├── arm-none-eabi-m4
 │   ├── gdbmacros
-│   └── sim
+│   ├── mips
+│   ├── sim
+│   └── sim-mips
 ├── crypto
 │   ├── mbedtls
 │   └── tinycrypt
@@ -160,6 +165,8 @@ repos/apache-mynewt-core/
 │   ├── json
 │   └── tinycbor
 ├── fs
+│   ├── disk
+│   ├── fatfs
 │   ├── fcb
 │   ├── fs
 │   └── nffs
@@ -205,7 +212,6 @@ repos/apache-mynewt-core/
 │   ├── crash_test
 │   ├── flash_test
 │   ├── runtest
-│   ├── testreport
 │   └── testutil
 ├── time
 │   └── datetime
@@ -214,7 +220,7 @@ repos/apache-mynewt-core/
     ├── crc
     └── mem
 
-87 directories, 9 files
+94 directories, 9 files
 ```
 
 As you can see, the core of the Apache Mynewt operating system has been brought 
@@ -226,21 +232,44 @@ into your local directory.
 
 You have already built your first basic project. You can ask Newt to execute the unit tests in a package. For example, to test the `libs/os` package in the `apache-mynewt-core` repo, call newt as shown below.
 
-```
+```no-highlight
 $ newt test @apache-mynewt-core/sys/config
 Testing package @apache-mynewt-core/sys/config/test-fcb
 Compiling bootutil_misc.c
 Compiling image_ec.c
 Compiling image_rsa.c
 Compiling image_validate.c
-<snip>
+
+    ...
+
+Linking ~/dev/myproj/bin/targets/unittest/sys_config_test-fcb/app/sys/config/test-fcb/sys_config_test-fcb.elf
+Executing test: ~/dev/myproj/bin/targets/unittest/sys_config_test-fcb/app/sys/config/test-fcb/sys_config_test-fcb.elf
+Testing package @apache-mynewt-core/sys/config/test-nffs
+Compiling repos/apache-mynewt-core/encoding/base64/src/hex.c
+Compiling repos/apache-mynewt-core/fs/fs/src/fs_cli.c
+Compiling repos/apache-mynewt-core/fs/fs/src/fs_dirent.c
+Compiling repos/apache-mynewt-core/fs/fs/src/fs_mkdir.c
+Compiling repos/apache-mynewt-core/fs/fs/src/fs_mount.c
+Compiling repos/apache-mynewt-core/encoding/base64/src/base64.c
+Compiling repos/apache-mynewt-core/fs/fs/src/fs_file.c
+Compiling repos/apache-mynewt-core/fs/disk/src/disk.c
+Compiling repos/apache-mynewt-core/fs/fs/src/fs_nmgr.c
+Compiling repos/apache-mynewt-core/fs/fs/src/fsutil.c
+Compiling repos/apache-mynewt-core/fs/nffs/src/nffs.c
+
+     ...
+
+Linking ~/dev/myproj/bin/targets/unittest/sys_config_test-nffs/app/sys/config/test-nffs/sys_config_test-nffs.elf
+Executing test: ~/dev/myproj/bin/targets/unittest/sys_config_test-nffs/app/sys/config/test-nffs/sys_config_test-nffs.elf
+Passed tests: [sys/config/test-fcb sys/config/test-nffs]
+All tests passed
 ```
 
 **NOTE:** If you've installed the latest gcc using homebrew on your Mac, you will likely be running gcc-6. Make sure you have adjusted the compiler.yml configuration to reflect that as noted in [Native Install Option](native_tools.md). You can choose to downgrade to gcc-5 in order to use the default gcc compiler configuration for MyNewt.
 
 **NOTE:** If you are running the standard gcc for 64-bit machines, it does not support 32-bit. In that case you will see compilation errors. You need to install multiboot gcc (e.g. gcc-multilib if you running on a 64-bit Ubuntu).
 
-```
+```no-highlight
 $ brew uninstall gcc-6
 $ brew link gcc-5
 ```
@@ -251,14 +280,21 @@ To test all the packages in a project, specify `all` instead of the package name
 
 ```no-highlight
 $ newt test all
+Testing package @apache-mynewt-core/boot/boot_serial/test
+Compiling repos/apache-mynewt-core/boot/boot_serial/test/src/boot_test.c
+Compiling repos/apache-mynewt-core/boot/boot_serial/test/src/testcases/boot_serial_setup.c
+
+     ...
+
+Linking ~/dev/myproj/bin/targets/unittest/boot_boot_serial_test/app/boot/boot_serial/test/boot_boot_serial_test.elf
+
 ...lots of compiling and testing...
-...about 2 minutes later ...
-Compiling mn_sock_test.c
-Archiving mn_socket.a
-Linking test_mn_socket
-Executing test: /Users/dsimmons/myproj/bin/unittest/sys/mn_socket/test_mn_socket
-Passed tests: [libs/json libs/util libs/mbedtls net/nimble/host hw/hal libs/bootutil sys/log sys/config sys/fcb fs/nffs libs/os libs/boot_serial sys/mn_socket]
+
+Linking ~/dev/myproj/bin/targets/unittest/util_cbmem_test/app/util/cbmem/test/util_cbmem_test.elf
+Executing test: ~/dev/myproj/bin/targets/unittest/util_cbmem_test/app/util/cbmem/test/util_cbmem_test.elf
+Passed tests: [boot/boot_serial/test boot/bootutil/test crypto/mbedtls/test encoding/base64/test encoding/cborattr/test encoding/json/test fs/fcb/test fs/nffs/test kernel/os/test net/ip/mn_socket/test net/nimble/host/test net/oic/test sys/config/test-fcb sys/config/test-nffs sys/flash_map/test sys/log/full/test util/cbmem/test]
 All tests passed
+
 ```
 
 <br>
@@ -267,19 +303,25 @@ All tests passed
 
 To build and run your new application, simply issue the following command:
 
-```
+```no-highlight
 $ newt build my_blinky_sim 
 Building target targets/my_blinky_sim
-Compiling main.c
-Archiving blinky.a
-Compiling hal_bsp.c
-Compiling os_bsp.c
-Compiling sbrk.c
-Archiving native.a
-Compiling flash_map.c
-<snip>
-Linking blinky.elf
-App successfully built: ~/myproj/bin/targets/my_blinky_sim/app/apps/blinky/blinky.elf
+Compiling repos/apache-mynewt-core/hw/hal/src/hal_common.c
+Compiling repos/apache-mynewt-core/hw/drivers/uart/src/uart.c
+Compiling repos/apache-mynewt-core/hw/hal/src/hal_flash.c
+Compiling repos/apache-mynewt-core/hw/bsp/native/src/hal_bsp.c
+Compiling repos/apache-mynewt-core/hw/drivers/uart/uart_hal/src/uart_hal.c
+Compiling apps/blinky/src/main.c
+
+    ...
+
+
+Archiving sys_mfg.a
+Archiving sys_sysinit.a
+Archiving util_mem.a
+Linking ~/dev/myproj/bin/targets/my_blinky_sim/app/apps/blinky/blinky.elf
+Target successfully built: targets/my_blinky_sim
+
 ```
 
 <br>
@@ -289,7 +331,7 @@ App successfully built: ~/myproj/bin/targets/my_blinky_sim/app/apps/blinky/blink
 You can run the simulated version of your project and see the simulated LED
 blink. If you are using newt docker, use `newt run` to run the simulated binary.
 
-```
+```no-highlight
 $ newt run my_blinky_sim
 No download script for BSP hw/bsp/native
 Debugging /workspace/bin/my_blinky_sim/apps/blinky/blinky.elf

--- a/docs/os/get_started/serial_access.md
+++ b/docs/os/get_started/serial_access.md
@@ -49,7 +49,7 @@ It should look like this:
 On the NRF52DK developer kit board, the Rx pin is P0.08, so you'll attach your
 jumper wire from the Tx pin (D0) of the FT232H board here.
 
-The TX Pin is pin P0.08, so you'll attache the jumper wire from the Rx Pin (D1)
+The TX Pin is pin P0.06, so you'll attache the jumper wire from the Rx Pin (D1)
 on the FT232H board here. 
 
 Finally, the GND wire should go to the GND Pin on the NRF52DK. When you're

--- a/docs/os/modules/bootloader/bootloader.md
+++ b/docs/os/modules/bootloader/bootloader.md
@@ -228,15 +228,7 @@ sector at a time.  The swap status is necessary for resuming a swap operation
 if the device rebooted before a swap operation completed.
 
 3. Copy done: A single byte indicating whether the image in this slot is
-complete (0x01=d< bok@bok.net
-35d33
-< ericmanganaro@gmail.com
-42d39
-< tam@proxy.co
-55d51
-< nathan@natb1.com
-110d105
-< rvs@apache.orgone; 0xff=not done).
+complete (0x01=done, 0xff=not done).
 
 4. Image OK: A single byte indicating whether the image in this slot has been
 confirmed as good by the user (0x01=confirmed; 0xff=not confirmed).

--- a/docs/os/tutorials/arduino_zero.md
+++ b/docs/os/tutorials/arduino_zero.md
@@ -235,7 +235,7 @@ If the `newt load` command outputs the following error messages, you will need t
 ```
 $ newt load arduino_boot -v
 Loading bootloader
-Error: Downloading ~/dev/arduino_zero/bin/targets/arduino_boot/app/apps/boot/boot.elf.bin to 0x0
+Error: Downloading ~/dev/myproj/bin/targets/arduino_boot/app/apps/boot/boot.elf.bin to 0x0
 Open On-Chip Debugger 0.9.0 (2015-11-15-05:39)
 Licensed under GNU GPL v2
 For bug reports, read
@@ -284,7 +284,7 @@ Run the `newt load arduino_boot` command again after erasing the board.
 
 After you load the bootloader successfully onto your board, you can load and run the Blinky application. 
 
-Run the `newt run arduino_blinky 1.0.0` command to build the arduino_blinky target (if necessary), create an image with verison 1.0.0, load the image onto the board, and start a debugger session. 
+Run the `newt run arduino_blinky 1.0.0` command to build the arduino_blinky target (if necessary), create an image with version 1.0.0, load the image onto the board, and start a debugger session. 
 ```no-highlight
 $ newt run arduino_blinky 1.0.0
 App image succesfully generated: ~/dev/myproj/bin/targets/arduino_blinky/app/apps/blinky/blinky.img
@@ -342,7 +342,7 @@ Continuing.
 
 <br>
 
-**NOTE:** The 1.0.0 is the version number to assign to the image. You may assign an abitrary version number. If you are not providing remote upgrade, and are just developing locally, you can provide 1.0.0 for every image version.
+**NOTE:** The 1.0.0 is the version number to assign to the image. You may assign an arbitrary version number. If you are not providing remote upgrade, and are just developing locally, you can provide 1.0.0 for every image version.
 
 If you want the image to run without the debugger connected, simply quit the
 debugger and restart the board.  The image you programmed will come up and run on 

--- a/docs/os/tutorials/arduino_zero.md
+++ b/docs/os/tutorials/arduino_zero.md
@@ -10,13 +10,13 @@ Ensure that you have met the following prerequisites before continuing with this
 * Have an Arduino Zero board.  
 Note: There are many flavors of Arduino. Make sure you are using an Arduino Zero. See below for the versions of Arduino Zero that are compatible with this tutorial.
 * Have Internet connectivity to fetch remote Mynewt components.
+* Have a computer to build a Mynewt application and connect to the board over USB.
 * Have a Micro-USB cable to connect the board and the computer.
-* Have a computer to build a Mynewt application and connect to your board over USB.
 * Install the Newt tool and toolchains (See [Basic Setup](/os/get_started/get_started.md)).
 * Create a project space (directory structure) and populated it with the core code repository (apache-mynewt-core) or know how to as explained in [Creating Your First Project](/os/get_started/project_create).
 * Read the Mynewt OS [Concepts](/os/get_started/vocabulary.md) section. 
 
-This tutorial has been tested on the following three Arduino Zero boards - Zero, M0 Pro, and Zero-Pro.
+This tutorial uses the Arduino Zero Pro board. The tutorial has been tested on the following three Arduino Zero boards - Zero, M0 Pro, and Zero-Pro.
 
 <img src="https://www.arduino.cc/en/uploads/Main/Zero_Usb_Ports.jpg" alt="Drawing" style="width: 390px;"/>
 <img src="http://www.arduino.org/images/products/Arduino-M0Pro-flat.jpg" alt="Drawing" style="width: 310px;"/>
@@ -81,7 +81,7 @@ $
 ```
 
 <br>
-Install the project dependencies using the `newt install` command (You can specify ```-v``` for verbose output):
+Install the project dependencies using the `newt install` command (you can specify ```-v``` for verbose output):
 ```no-highlight
 $ newt install
 apache-mynewt-core
@@ -94,10 +94,9 @@ $
 **NOTE:** If there has been a new release of a repo used in your project since you last installed it, the `1-latest` version for the repo in the `project.yml` file will refer to the new release and will not match the installed files. In that case you will get an error message saying so and you will need to run `newt upgrade` to overwrite the existing files with the latest codebase.
 
 <br>
-### Create a Target for the Bootloader
-You need to create two targets, one for the bootloader and one for the Blinky application.  
+You need to create two targets for the Arduino Zero Pro board, one for the bootloader and one for the Blinky application.  
 <br>
-Run the following `newt target` commands, from your project directory (ex. ~/dev/myproj), to create a bootloader target for the Arduino Zero Pro board.  We name the target `arduino_boot`.
+Run the following `newt target` commands, from your project directory, to create a bootloader target.  We name the target `arduino_boot`.
 
 ```no-highlight
 $ newt target create arduino_boot
@@ -111,7 +110,7 @@ $ newt target set arduino_boot syscfg=BSP_ARDUINO_ZERO_PRO=1
 Target targets/arduino_boot successfully set target.syscfg to BSP_ARDUINO_ZERO_PRO=1
 $
 ```
-**Note:** If you have an Arduino Zero instead of a Arduino Zero Pro board, replace `BSP_ARDUINO_ZERO_PRO`  with `BSP_ARDUINO_ZERO` in the last `newt target set` command.
+**Note:** If you have an Arduino Zero instead of an Arduino Zero Pro or Arduino M0 Pro board, replace `BSP_ARDUINO_ZERO_PRO`  with `BSP_ARDUINO_ZERO` in the last `newt target set` command.
 
 These commands perform the following:
 
@@ -129,7 +128,7 @@ These commands perform the following:
 See the [Concepts](../get_started/vocabulary.md) section for more information on setting options.
 <br>
 ###Create a Target for the Blinky Application
-Run the following `newt target` commands to create your Blinky application target.  We name the application target `arduino_blinky`.
+Run the following `newt target` commands to create the Blinky application target.  We name the application target `arduino_blinky`.
 
 ```no-highlight
 $ newt target create arduino_blinky
@@ -151,7 +150,7 @@ $
 
 ### Build the Bootloader
 
-Run the `newt build arduino_boot` command to build a bootloader for your arduino board:
+Run the `newt build arduino_boot` command to build the bootloader:
 
 ```no-highlight
 $ newt build arduino_boot
@@ -182,7 +181,7 @@ Target successfully built: targets/arduino_boot
 
 ### Build the Blinky Application
 
-Run the `newt build arduino_blinky` command to build your Blinky application image:
+Run the `newt build arduino_blinky` command to build the Blinky application image:
 
 ```no-highlight
 $ newt build arduino_blinky
@@ -208,7 +207,7 @@ Target successfully built: targets/arduino_blinky
 Connect your computer to the Arduino Zero (from now on we'll call this the
 target) with a Micro-USB cable through the Programming Port as shown below.
 Mynewt will load the image onto the board and  debug the target through this port. You should see a
-little green LED come on. That means the board has power.
+green LED come on that indicates the board has power.
 
 No external debugger is required.  The Arduino Zero comes with an internal
 debugger that can be accessed by Mynewt.
@@ -222,16 +221,17 @@ The images below show the Arduino Zero Programming Port.
 
 ### Load the Bootloader onto the Board
 
-Run the `newt load arduino_boot` command to load the bootloader onto your board:
+Run the `newt load arduino_boot` command to load the bootloader onto the board:
 
 ```no-highlight
 $ newt load arduino_boot
 Loading bootloader
 $
 ```
-The bootloader is loaded onto your board succesfully when the `newt load` command returns to the command prompt with no messages. You can proceed to load and run your Blinky application image (See [Run the Blinky Application](#runimage)).
+The bootloader is loaded onto your board succesfully when the `newt load` command returns to the command prompt after the `Loading bootloader` status message.  You can proceed to load and run your Blinky application image (See [Run the Blinky Application](#runimage)).
 
-If the `newt load` command outputs the following error messages, you will need to erase your board.
+If the `newt load` command outputs the following error messages, you will need to erase the board.
+
 ```
 $ newt load arduino_boot -v
 Loading bootloader
@@ -284,9 +284,9 @@ Run the `newt load arduino_boot` command again after erasing the board.
 
 After you load the bootloader successfully onto your board, you can load and run the Blinky application. 
 
-Run the `newt run arduino_blinky 0.0.0` command to build the arduino_blinky target (if necessary), create an image with verison 0.0.0, load the image onto the board, and start a debugger session. 
+Run the `newt run arduino_blinky 1.0.0` command to build the arduino_blinky target (if necessary), create an image with verison 1.0.0, load the image onto the board, and start a debugger session. 
 ```no-highlight
-$ newt run arduino_blinky 0.0.0
+$ newt run arduino_blinky 1.0.0
 App image succesfully generated: ~/dev/myproj/bin/targets/arduino_blinky/app/apps/blinky/blinky.img
 Loading app image into slot 1
 [~/dev/myproj/repos/mynewt_arduino_zero/hw/bsp/arduino_zero/arduino_zero_debug.sh ~/dev/myproj/repos/mynewt_arduino_zero/hw/bsp/arduino_zero ~/dev/myproj/bin/targets/arduino_blinky/app/apps/blinky/blinky]
@@ -342,7 +342,7 @@ Continuing.
 
 <br>
 
-**NOTE:** The 0.0.0 is the version number to assign to the images.  If you are not providing remote upgrade, and are just developing locally, you can provide 0.0.0 for every image version.
+**NOTE:** The 1.0.0 is the version number to assign to the image. You may assign an abitrary version number. If you are not providing remote upgrade, and are just developing locally, you can provide 1.0.0 for every image version.
 
 If you want the image to run without the debugger connected, simply quit the
 debugger and restart the board.  The image you programmed will come up and run on 

--- a/docs/os/tutorials/blinky_primo.md
+++ b/docs/os/tutorials/blinky_primo.md
@@ -17,12 +17,12 @@ Ensure that you have met the following prerequisites before continuing with this
 
 * Have an Arduino Primo
 * Have Internet connectivity to fetch remote Mynewt components.
+* Have a computer to build a Mynewt application and connect to the` board over USB.
 * Have a Micro-USB cable to connect the board and the computer.
-* Have a computer to build a Mynewt application and connect to your board over USB.
 * Install the Newt tool and toolchains (See [Basic Setup](/os/get_started/get_started.md)).
 * Create a project space (directory structure) and populated it with the core code repository (apache-mynewt-core) or know how to as explained in [Creating Your First Project](/os/get_started/project_create).
 * Read the Mynewt OS [Concepts](/os/get_started/vocabulary.md) section.
-* Debugger - choose one of the two options below. Option 1 requires additional hardware but very easy to set up. Option 2 is free software install but not as simple as Option 1.
+* Install a debugger - choose one of the two options below. Option 1 requires additional hardware but very easy to set up. Option 2 is free software install but not as simple as Option 1.
 
 <br>
 
@@ -33,7 +33,7 @@ Ensure that you have met the following prerequisites before continuing with this
 
 ##### Option 2
 
-* No additional hardware is required but a version of OpenOCD 0.10.0 that is currently in development needs to be installed. A patch for the nRF52 has been applied to the OpenOCD code in development and a tarball has been made available for download [here](downloads/openocd-wnrf52.tgz). Untar it. From the top of the directory tree ("openocd-code-89bf96ffe6ac66c80407af8383b9d5adc0dc35f4"), build it using the following configuration:
+ No additional hardware is required but a version of OpenOCD 0.10.0 that is currently in development needs to be installed. A patch for the nRF52 has been applied to the OpenOCD code in development and a tarball has been made available for download [here](downloads/openocd-wnrf52.tgz). Untar it. From the top of the directory tree ("openocd-code-89bf96ffe6ac66c80407af8383b9d5adc0dc35f4"), build it using the following configuration:
 
 ```
 $./configure --enable-cmsis-dap --enable-openjtag_ftdi --enable-jlink --enable-stlink
@@ -94,14 +94,14 @@ Run the following commands to create a new project:
 
 Create two targets for the Arduino Primo board - one for the bootloader and one for the Blinky application.
 
-Run the following `newt target` commands to create a bootloader target. We name the target `primo_boot`:
+Run the following `newt target` commands, from your project directory, to create a bootloader target. We name the target `primo_boot`.
 
 ```no-highlight
 $ newt target create primo_boot
 $ newt target set primo_boot app=@apache-mynewt-core/apps/boot bsp=@apache-mynewt-core/hw/bsp/arduino_primo_nrf52 build_profile=optimized
 ```
 <br>
-Run the following `newt target` commands to create a target for your Blinky application. We name the target `primoblinky`:
+Run the following `newt target` commands to create a target for the Blinky application. We name the target `primoblinky`.
 ```no-highlight
 $ newt target create primoblinky
 $ newt target set primoblinky app=apps/blinky bsp=@apache-mynewt-core/hw/bsp/arduino_primo_nrf52 build_profile=debug
@@ -110,13 +110,12 @@ $ newt target set primoblinky app=apps/blinky bsp=@apache-mynewt-core/hw/bsp/ard
 If you are using openocd, run the following `newt target set` commands:
 
 ```no-highlight
-$ newt target set primoblinky syscfg=OPENCD_DEBUG=1
-$ newt target set primo_boot syscfg=OPENCD_DEBUG=1
-
+$ newt target set primoblinky syscfg=OPENOCD_DEBUG=1
+$ newt target set primo_boot syscfg=OPENOCD_DEBUG=1
 ```
 
 <br>
-You can run the `newt target show` command to verify your target settings:
+You can run the `newt target show` command to verify the target settings:
 
 ```no-highlight
 $ newt target show
@@ -196,17 +195,15 @@ App image succesfully generated: ~/dev/myproj/bin/targets/primoblinky/app/apps/b
 <br>
 
 ### Connect to the Board
-
-Connect the Segger J-Link debug probe to the JTAG port on the Primo board using the Jlink 9-pin adapter and cable. Note that there are two JTAG ports on the board. Use the one nearest to the reset button as shown in the picture. Also use a micro USB 2.0 cable to connect the Primo board to one of your laptop's USB host ports.
+* Connect a micro USB cable to the Arduino Primo board and to your computer's USB port.
+* If you are using the Segger J-Link debug probe, connect the debug probe to the JTAG port on the Primo board using the Jlink 9-pin adapter and cable. Note that there are two JTAG ports on the board. Use the one nearest to the reset button as shown in the picture. 
 
 ![J-Link debug probe to Arduino](pics/primo-jlink.jpg "Connecting J-Link debug probe to Arduino Primo")
-        
-<br>
 
-**Note:** If you are going the OpenOCD route, you do not need to attach this connector. 
+**Note:** If you are using the OpenOCD debugger,  you do not need to attach this connector. 
 
 ### Load the Bootloader and the Blinky Application Image
-Run the `newt load primo_boot` command to load the bootloader onto your board:
+Run the `newt load primo_boot` command to load the bootloader onto the board:
 
 ```no-highlight
 $ newt load primo_boot
@@ -214,16 +211,17 @@ Loading bootloader
 $
 ```
 <br>
-Run the `newt load primoblinky` command to load Blinky application image onto your board.
+Run the `newt load primoblinky` command to load the Blinky application image onto the board.
+
 ```no-highlight
 $ newt  load primoblinky 
 Loading app image into slot 1
 $
 ```
 
-You should see the LED on your board blink!
+You should see the LED on the board blink!
 
-Note: If the LED does not blink, try resetting your board.
+Note: If the LED does not blink, try resetting the board.
 
 
 <br>

--- a/docs/os/tutorials/nRF52.md
+++ b/docs/os/tutorials/nRF52.md
@@ -8,11 +8,11 @@ Learn how to use packages from a default application repository of Mynewt to bui
 
 Create a project with a simple app that blinks an LED on the nRF52 board from Nordic Semiconductors.  Download the application to the target and watch it blink!
 
-Note that there are several versions of the nRF52 in the market. The boards tested with this tutorial are listed under "Hardware needed" below.
+Note that there are several versions of the nRF52 in the market. The boards tested with this tutorial are listed under "Prerequisites".
 
 <br>
 
-### Prerequistes
+### Prerequisites
 
 Ensure that you have met the following prerequisites before continuing with this tutorial:
 
@@ -20,12 +20,13 @@ Ensure that you have met the following prerequisites before continuing with this
     * Dev Kit from Nordic - PCA 10040
     * Eval Kit from Rigado - BMD-300-EVAL-ES
 * Have Internet connectivity to fetch remote Mynewt components.
+* Have a computer to build a Mynewt application and connect to the board over USB.
 * Have a Micro-USB cable to connect the board and the computer.
-* Have computer to build a Mynewt application and connect to your board over USB.
 * Install the Newt tool and toolchains (See [Basic Setup](/os/get_started/get_started.md)).
 * Create a project space (directory structure) and populated it with the core code repository (apache-mynewt-core) or know how to as explained in [Creating Your First Project](/os/get_started/project_create).
 * Read the Mynewt OS [Concepts](/os/get_started/vocabulary.md) section.
 
+This tutorial uses the Nordic NRF52DK board.
 <br>
 
 ### Create a Project  
@@ -52,10 +53,10 @@ Run the following commands to create a new project:
 
 Create two targets for the nRF52-DK board - one for the bootloader and one for the Blinky application.
 
-Run the following `newt target` commands, from your project directory (~/dev/myproj), to create a bootloader target. We name the target `nrf52_boot`:
+Run the following `newt target` commands, from your project directory, to create a bootloader target. We name the target `nrf52_boot`:
 
 <font color="#F2853F">
-Note: For this tutorial, we are using the nRF52-DK board.  You must specify the correct bsp for the board you are using. </font> 
+Note: This tutorial uses the Nordic nRF52-DK board.  You must specify the correct bsp for the board you are using. </font> 
 
 * For the Nordic Dev Kit choose @apache-mynewt-core/hw/bsp/nrf52dk instead (in the highlighted lines)
 * For the Rigado Eval Kit choose @apache-mynewt-core/hw/bsp/bmd300eval instead (in the highlighted lines)
@@ -68,17 +69,16 @@ $ newt target set nrf52_boot build_profile=optimized
 ```
 
 <br>
-Run the following `newt target` commands to create a target for your Blinky application. We name the target `nrf52_blinky`:
+Run the following `newt target` commands to create a target for the Blinky application. We name the target `nrf52_blinky`.
 
 ```hl_lines="3" 
 $ newt target create nrf52_blinky
 $ newt target set nrf52_blinky app=apps/blinky
 $ newt target set nrf52_blinky bsp=@apache-mynewt-core/hw/bsp/nrf52dk
 $ newt target set nrf52_blinky build_profile=debug
-
 ```
 <br>
-You can run the `newt target show` command to verify your target settings:
+You can run the `newt target show` command to verify the target settings:
 
 ```no-highlight
 $ newt target show 
@@ -155,12 +155,12 @@ App image succesfully generated: ~/dev/myproj/bin/targets/nrf52_blinky/app/apps/
 
 ### Connect to the Board
 
-* Connect a micro-USB cable from your computer to the micro-USB port on your nRF52-DK board.
+* Connect a micro-USB cable from your computer to the micro-USB port on the NRF52DK board.
 * Turn the power on the board to ON. You should see the green LED light up on the board.
         
 ### Load the Bootloader and the Blinky Application Image
 
-Run the `newt load nrf52_boot` command to load the bootloader onto your board: 
+Run the `newt load nrf52_boot` command to load the bootloader onto the board: 
 
 ```no-highlight
 $ newt load nrf52_boot
@@ -168,13 +168,13 @@ Loading bootloader
 $
 ```
 <br>
-Run the `newt load nrf52_blinky` command to load Blinky application image onto your board.
+Run the `newt load nrf52_blinky` command to load the Blinky application image onto the board.
 ```no-highlight
-$ newt -v load nrf52_blinky
+$ newt load nrf52_blinky
 Loading app image into slot 1
 ```
 
-You should see the LED1 on your board blink!
+You should see the LED1 on the board blink!
 
 Note: If the LED does not blink, try resetting your board.
 

--- a/docs/os/tutorials/nRF52.md
+++ b/docs/os/tutorials/nRF52.md
@@ -26,7 +26,7 @@ Ensure that you have met the following prerequisites before continuing with this
 * Create a project space (directory structure) and populated it with the core code repository (apache-mynewt-core) or know how to as explained in [Creating Your First Project](/os/get_started/project_create).
 * Read the Mynewt OS [Concepts](/os/get_started/vocabulary.md) section.
 
-This tutorial uses the Nordic NRF52DK board.
+This tutorial uses the Nordic nRF52-DK board.
 <br>
 
 ### Create a Project  
@@ -155,7 +155,7 @@ App image succesfully generated: ~/dev/myproj/bin/targets/nrf52_blinky/app/apps/
 
 ### Connect to the Board
 
-* Connect a micro-USB cable from your computer to the micro-USB port on the NRF52DK board.
+* Connect a micro-USB cable from your computer to the micro-USB port on the nRF52-DK board.
 * Turn the power on the board to ON. You should see the green LED light up on the board.
         
 ### Load the Bootloader and the Blinky Application Image

--- a/docs/os/tutorials/olimex.md
+++ b/docs/os/tutorials/olimex.md
@@ -149,12 +149,12 @@ Configure the board to bootload from flash memory and to use the JTAG/SWD for th
 * Locate the boot jumpers on the lower right corner of the board.  **B1_1/B1_0** and **B0_1/B0_0** are PTH jumpers to control the boot mode when a bootloader is present.  These two jumpers must be moved together.  The board searches for the bootloader in three places: User Flash Memory, System Memory or the Embedded SRAM. For this Blinky project, we configure the board to boot from flash by jumpering **B0_0** and **B1_0**.
 **Note:** The markings on the board may not always be accurate, and you should always refer to the manual for the correct positioning. 
 
-* Locate the **Power Input Select** jumpers on the lower left corner of the board.  Set the Power Select jumpers to position 3 and 4 to use the JTAG/SWD for the power source. If you would like to use a different power source, refer to [OLIMEZ STM32-E407] user manual](https://www.olimex.com/Products/ARM/ST/STM32-E407/resources/STM32-E407.pdf) to pin specificiation.
+* Locate the **Power Input Select** jumpers on the lower left corner of the board.  Set the Power Select jumpers to position 3 and 4 to use the JTAG/SWD for the power source. If you would like to use a different power source, refer to the [OLIMEX STM32-E407 user manual](https://www.olimex.com/Products/ARM/ST/STM32-E407/resources/STM32-E407.pdf) for pin specifications.
  
 
 * Connect the JTAG connector to the JTAG/SWD interface on the board. 
 
-* Connect the USB A-B cable to the ARM-USB-TINY-H connector and your personal computer. 
+* Connect the USB A-B cable to the ARM-USB-TINY-H connector and your computer.
 
 * Check that the red PWR LED lights up.
 <br>

--- a/docs/os/tutorials/olimex.md
+++ b/docs/os/tutorials/olimex.md
@@ -13,9 +13,9 @@ Ensure that you have met the following prerequisites before continuing with this
 
 * Have a STM32-E407 development board from Olimex. 
 * Have a ARM-USB-TINY-H connector with JTAG interface for debugging ARM microcontrollers (comes with the ribbon cable to hook up to the board)
-* Have USB A-B type cable to connect the debugger to your personal computer.
 * Have Internet connectivity to fetch remote Mynewt components.
-* Have a computer to build a Mynewt application and connect to your board over USB.
+* Have a computer to build a Mynewt application and connect to the board over USB.
+* Have USB A-B type cable to connect the debugger to your computer.
 * Install the Newt tool and toolchains (See [Basic Setup](/os/get_started/get_started.md)).
 * Create a project space (directory structure) and populated it with the core code repository (apache-mynewt-core) or know how to as explained in [Creating Your First Project](/os/get_started/project_create).
 * Read the Mynewt OS [Concepts](/os/get_started/vocabulary.md) section.
@@ -50,7 +50,7 @@ Run the following commands to create a new project:
 
 Create two targets for the Olimex board - one for the bootloader and one for the Blinky application.
 
-Run the following `newt target` commands to create a bootloader target. We name the target `boot_olimex`:
+Run the following `newt target` commands, from your project directory,  to create a bootloader target. We name the target `boot_olimex`.
 
 ```no-highlight
 $ newt target create boot_olimex
@@ -60,7 +60,7 @@ $ newt target set boot_olimex bsp=@apache-mynewt-core/hw/bsp/olimex_stm32-e407_d
 ```
 
 <br>
-Run the following `newt target` commands to create a target for your Blinky application. We name the target `olimex_blinky`:
+Run the following `newt target` commands to create a target for the Blinky application. We name the target `olimex_blinky`.
 
 ```no-highlight
 $ newt target create olimex_blinky
@@ -73,7 +73,7 @@ $ newt target set olimex_blinky app=apps/blinky
 <br>
 
 ### Build the Bootloader 
-Run the `newt build boot_olimex` command to build the boot loader image:
+Run the `newt build boot_olimex` command to build the bootloader:
 
 ```no-highlight
 $ newt build boot_olimex
@@ -124,7 +124,7 @@ Target successfully built: targets/olimex_blinky
 <br>
 
 ### Sign and Create the Blinky Application Image
-Run the `newt create-image olimex_blinky 1.0.0` command to sign and create an image file for your blinky application. You may assign an arbitrary version (e.g. 1.0.0) number.
+Run the `newt create-image olimex_blinky 1.0.0` command to sign and create an image file for the blinky application. You may assign an arbitrary version (e.g. 1.0.0) number.
 
 
 ```no-highlight
@@ -135,7 +135,7 @@ App image succesfully generated: ~/dev/myproj/bin/targets/olimex_blinky/app/apps
 
 ### Connect to the Board
 
-Configure your board to bootload from flash memory and to use the JTAG/SWD for the power source. Refer to the following diagrams to locate the boot jumpers and power input select jumpers on your board.
+Configure the board to bootload from flash memory and to use the JTAG/SWD for the power source. Refer to the following diagrams to locate the boot jumpers and power input select jumpers on the board.
 <br>
 
 <p align="center">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,7 +49,7 @@ pages:
         - 'Events and Event Queues': 'os/tutorials/event_queue.md'
         - 'Project Slinky for remote comms':
             - 'Slinky on sim device': 'os/tutorials/project-slinky.md'
-            - 'Slinky on STM32 board': 'os/tutorials/project-target-slinky.md'
+            - 'Slinky on Nordic nRF52 board': 'os/tutorials/project-target-slinky.md'
         - 'Enable Newt Manager in any app': 'os/tutorials/add_newtmgr.md' 
         - 'Enable the OS Shell and Console': 'os/tutorials/add_shell.md'
         - 'BLE app to check stats via console': 'os/tutorials/bletiny_project.md'
@@ -83,6 +83,7 @@ pages:
                     - 'os_sched_insert': 'os/core_os/context_switch/os_sched_insert.md'
                     - 'os_sched_next_task': 'os/core_os/context_switch/os_sched_next_task.md'
                     - 'os_sched_os_timer_exp': 'os/core_os/context_switch/os_sched_os_timer_exp.md'
+                    - 'os_sched_remove': 'os/core_os/context_switch/os_sched_remove.md'
                     - 'os_sched_resort': 'os/core_os/context_switch/os_sched_resort.md'
                     - 'os_sched_set_current_task': 'os/core_os/context_switch/os_sched_set_current_task.md'
                     - 'os_sched_sleep': 'os/core_os/context_switch/os_sched_sleep.md'
@@ -101,6 +102,7 @@ pages:
                     - 'os_task_count': 'os/core_os/task/os_task_count.md'
                     - 'os_task_info_get_next': 'os/core_os/task/os_task_info_get_next.md'
                     - 'os_task_init': 'os/core_os/task/os_task_init.md'
+                    - 'os_task_remove': 'os/core_os/task/os_task_remove.md'
             - Event Queues:
                 - toc: 'os/core_os/event_queue/event_queue.md'
                 - 'Functions':
@@ -128,6 +130,7 @@ pages:
                 - toc: 'os/core_os/memory_pool/memory_pool.md'
                 - 'Functions/Macros':
                     - 'os_memblock_get': 'os/core_os/memory_pool/os_memblock_get.md'
+                    - 'os_mempool_info_get_next': 'os/core_os/memory_pool/os_mempool_info_get_next.md'
                     - 'os_mempool_init': 'os/core_os/memory_pool/os_mempool_init.md'
                     - 'os_memblock_put': 'os/core_os/memory_pool/os_memblock_put.md'
                     - 'OS_MEMPOOL_BYTES': 'os/core_os/memory_pool/OS_MEMPOOL_BYTES.md'


### PR DESCRIPTION
1) Updated blinky for arduino zero, arduino primo, olimex, nRF52 -  
 Removed features, updated paths, general cleanup to make tutorials more consistent
2) Use updated olimex diagrams that shows power input select jumper location
   so user can configure power source from JTAG/SWD
3) Fix typo in bleprph tutorial.
4) Updated Concepts section to use updated newt target -h output
5) Updated newt install  for Mac and linux to use updated newt -h output.
6) Updated newt install for linux for GO version 1.6
7) Remove duplicate instance of Air Quality Sensor project from document tree
8) Removed embedded LUA from doc tree.