### PR TITLE
Doc Updates for 1.0

### DIFF
--- a/docs/newt/install/newt_linux.md
+++ b/docs/newt/install/newt_linux.md
@@ -48,10 +48,18 @@ If you want to build the *newt* tool from its source code, follow the following 
 
 * Next, install Go. When installed, Go offers you as a developer a language environment (to compile Go code), construct Go packages (to assemble Go packages) and import Go code (from github). In the next step, you will use the Go commands to import *newt* repo into your local Go environment.
 
-    **Note**: The Newt tool requires Go version 1.6 or later. Depending on the Ubuntu version you have, the following may install an earlier version. In that case, download the latest package of Go 1.6 from [https://golang.org/dl/](https://golang.org/dl/). You can search for more detailed instructions such as installing Go 1.6 on Ubuntu 14.04 which can be found at [https://www.digitalocean.com/community/tutorials/how-to-install-go-1-6-on-ubuntu-14-04](https://www.digitalocean.com/community/tutorials/how-to-install-go-1-6-on-ubuntu-14-04).
+    **Note**: The Newt tool requires Go version 1.7 or later.  Currently, the latest Go version that Ubuntu installs is 1.6. You can run `apt-get install golang-1.7-go` to install version 1.7. You can also download version 1.7 from [https://golang.org/dl/](https://golang.org/dl/). 
    
 ```no-highlight
-        $ sudo apt-get install golang 
+$sudo apt-get install golang-1.7-go
+Reading package lists... Done
+     ...
+Unpacking golang-1.7-go (1.7.1-2ubuntu1) ...
+Setting up golang-1.7-go (1.7.1-2ubuntu1) ...
+$
+$sudo ln -s /usr/lib/go-1.7/bin/go /usr/bin/go
+$go version
+go version go1.7.1 linux/amd64
 ```
 
 <br>    

--- a/docs/newt/newt_intro.md
+++ b/docs/newt/newt_intro.md
@@ -126,7 +126,7 @@ project.repositories:
 #
 repository.apache-mynewt-core:
      type: github
-     vers: 0-latest
+     vers: 1-latest
      user: apache
      repo: incubator-mynewt-core
 ```

--- a/docs/os/core_os/cputime/os_cputime.md
+++ b/docs/os/core_os/cputime/os_cputime.md
@@ -1,6 +1,6 @@
 # CPU Time
 
-The MyNewt `cputime` module provides high resolution time and timer support. This module is intended for use by BSPs, drivers, and network controllers. 
+The MyNewt `cputime` module provides high resolution time and timer support. 
 
 ## Description
 

--- a/docs/os/get_started/project_create.md
+++ b/docs/os/get_started/project_create.md
@@ -230,7 +230,7 @@ into your local directory.
 
 ### Test the project's packages
 
-You have already built your first basic project. You can ask Newt to execute the unit tests in a package. For example, to test the `libs/os` package in the `apache-mynewt-core` repo, call newt as shown below.
+You have already built your first basic project. You can ask Newt to execute the unit tests in a package. For example, to test the `sys/config` package in the `apache-mynewt-core` repo, call newt as shown below.
 
 ```no-highlight
 $ newt test @apache-mynewt-core/sys/config
@@ -333,9 +333,10 @@ blink. If you are using newt docker, use `newt run` to run the simulated binary.
 
 ```no-highlight
 $ newt run my_blinky_sim
-No download script for BSP hw/bsp/native
-Debugging /workspace/bin/my_blinky_sim/apps/blinky/blinky.elf
-<snip>
+Loading app image into slot 1
+    ...
+Debugging ~/dev/myproj/bin/targets/my_blinky_sim/app/apps/blinky/blinky.elf
+    ...
 Reading symbols from /bin/targets/my_blinky_sim/app/apps/blinky/blinky.elf...done.
 (gdb)
 ```
@@ -343,7 +344,7 @@ Type `r` at the `(gdb)` prompt to run the project. You will see an output indica
 
 If you natively install the toolchain, you can either use `newt run` or call the binary directly. Generally, `newt run` is the expected way to call things.
 
-```
+```no-highlight
 $ ./bin/targets/my_blinky_sim/app/apps/blinky/blinky.elf
 hal_gpio set pin  1 to 0
 ```

--- a/docs/os/get_started/vocabulary.md
+++ b/docs/os/get_started/vocabulary.md
@@ -103,9 +103,6 @@ Packages have a few features worth noting:
     they will inherit their functionality (header files, library definitions, etc.)
   * APIs: Packages can export named APIs, and they can require that certain 
     APIs be present, in order to compile.
-  * Features: Packages can operate differently depending on what named features are 
-    present in the system.  Packages can also export features to the rest of the 
-    Mynewt system.
 
 Everything that newt knows about within a project's directory is a package.  This 
 makes it very clean and easy to write re-usable components, which can describe their 
@@ -127,8 +124,9 @@ of your project.  Most targets consist of:
 
 Targets can also have additional items specified, including: 
 
+  * ```aflags```: Any additional assembler flags you might want to specify to the build.
   * ```cflags```: Any additional compiler flags you might want to specify to the build.
-  * ```features```: Any system level features you want to enable.
+  * ```lflags```: Any additional linker flags you might want to specify to the build.
 
 In order to create and manipulate targets, the *newt* tool offers a set of helper commands,
 you can find more information about these by issuing:

--- a/docs/os/modules/console/console.md
+++ b/docs/os/modules/console/console.md
@@ -10,15 +10,13 @@ Support is currently available for console access via the serial port on the har
 
 ###Description
 
-In the Mynewt OS, the console library comes in two versions:
+In the Mynewt OS, the console library comes in three versions:
 
 * The `sys/console/full` package implements the complete console functionality and API.
-
 * The `sys/console/stub` package implements stubs for the API.
+* The `sys/console/minimal` package implements minimal console functionality of reading from and writing to console.  It implements the `console_read()` and `console_write()` functions and stubs for all the other console functions.
 
-Both packages export the `console` API, and any package that uses 
-the console API must list `console` as a requirement. For example, the shell package defines the following `pkg.yml`
-file:
+All the packages export the `console` API, and any package that uses the console API must list `console` as a requirement its `pkg.yml` file:  
 
 ```no-highlight
 
@@ -32,10 +30,12 @@ pkg.req_apis:
     - console
 
 ```
+<br>
+The project `pkg.yml` file also specifies the version of the console package to use.
 
-The project `pkg.yml` file specifies the version of the console package to use.
-A project that requires the full console capability must list the `sys/console/full` package as a dependency 
-in its `pkg.yml` file.
+<br>
+####Using the Full Console Package
+A project that requires the full console capability must list the `sys/console/full` package as a dependency in its `pkg.yml` file.
 
 An example is the `slinky` application. It requires the full console capability and has the following
 `pkg.yml` file: 
@@ -54,15 +54,21 @@ pkg.deps:
        ...
     - sys/id
 ```
+<br>
+####Using the Stub Console Package
 
-On the other hand, a project may not have a physical console (e.g. a UART port to connect a terminal to) 
-but may have a dependency on a package that has console capability. In this case, you use 
-the console stub API and list the `sys/console/stub` package as a dependency in its `pkg.yml` file. 
+A project that uses console stub API must list the `sys/console/stub` package as a dependency in its `pkg.yml` file.
 
-An example is the bootloader project where we want to keep the size of the image small. It includes 
+Examples of when a project would use the console stubs might be:
+
+* A project may not have a physical console (e.g. a UART port to connect a terminal to) 
+but may have a dependency on a package that has console capability. 
+* A bootloader project where we want to keep the size of the image small. It includes 
 the `kernel/os` package that can print out messages on a console (e.g. if there is a hard fault).
 However, we do not want to use any console I/O capability in this particular bootloader project to 
-keep the size small. The project uses the console stub API and has the following `pkg.yml` file: 
+keep the size small. 
+
+The project would use the console stub API and has the following `pkg.yml` file: 
 
 ```no-highlight
 pkg.name: apps/boot
@@ -72,7 +78,33 @@ pkg.deps:
     - sys/console/stub
 
 ```
+<br>
 
+####Using the Minimal Console Package
+
+There might be projects that need to read and write data on a serial connection but do not need the full console capability. An example might be a project that supports serial image upgrade but does not need full newtmgr capability.  The project would use the console minimal API and has the following `pkg.yml` file: 
+
+```no-highlight
+pkg.name: apps/boot
+pkg.type: app
+pkg.description: Boot loader application.
+pkg.author: "Apache Mynewt <dev@mynewt.incubator.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+    - loader
+
+pkg.deps:
+    - boot/bootutil
+    - kernel/os
+    - sys/console/stub
+
+pkg.deps.BOOT_SERIAL.OVERWRITE:
+    - sys/console/minimal
+    - boot/boot_serial
+
+```			
+
+<br>
 Console has 2 modes for transmit; *blocking mode* and *non-blocking mode*. Usually the *non-blocking mode* is the 
 active one; the output buffer is drained by getting TX completion interrupts from hardware, and more data is added 
 based on these interrupts.

--- a/docs/os/modules/console/console_read.md
+++ b/docs/os/modules/console/console_read.md
@@ -1,7 +1,7 @@
 ## <font color="#F2853F" style="font-size:24pt"> console_read </font>
 
 ```c
-int console_read(char *str, int cnt)
+int console_read(char *str, int cnt, int *newline)
 ```
 
 Copies up to `cnt` bytes of received data to buffer pointed by `str`. Function tries to break the input into 
@@ -13,6 +13,8 @@ separate lines; once it encounters a newline character, it replaces that with en
 |-----------|-------------|
 | `str` |  Buffer where data is copied to.  |
 | `cnt` |  Maximum number of characters to copy.  |
+| `newline` | Pointer to an integer variable that is set to 1 when an newline character is received and set to 0 otherwise.
+              
 
 #### Returned values
 
@@ -29,12 +31,13 @@ task1_loop(void *arg)
     struct os_event *ev;
     char rx_msg[128];
     int rx_len;
+    int newline;
 
     while (1) {
         ev = os_eventq_get(&task1_evq);
         assert(ev);
         if (ev->ev_type == CONS_EV_TYPE) {
-            rx_len = console_read(rx_msg, sizeof(rx_msg));
+            rx_len = console_read(rx_msg, sizeof(rx_msg), &newline);
             if (rx_len) {
                     if (!strncmp(rx_msg, "reset", rx_len)) {
                             assert(0);

--- a/docs/os/tutorials/STM32F303.md
+++ b/docs/os/tutorials/STM32F303.md
@@ -211,7 +211,7 @@ Congratulations! You have built, downloaded, and run your first application usin
 
 Want to make your board do something a little more exciting with the LEDs? Then try making the modifications to the Blinky app to make it a [pin-wheel app](pin-wheel-mods.md) and you can light all the LEDs in a pin-wheel fashion.
 
-We have more fun tutorials for you to get your hands dirty. Be bold and try other Blinky-like [tutorials](../tutorials/nRF52.md) or try enabling additional functionality such as [remote comms](project-target-slinky.md) on the current board.
+We have more fun tutorials for you to get your hands dirty. Be bold and try other Blinky-like [tutorials](../tutorials/nRF52.md) or try enabling additional functionality such as [remote comms](project-slinky.md) on the current board.
 
 If you see anything missing or want to send us feedback, please do so by signing up for appropriate mailing lists on our [Community Page](../../community.md).
 

--- a/docs/os/tutorials/arduino_zero.md
+++ b/docs/os/tutorials/arduino_zero.md
@@ -1,20 +1,11 @@
 ## Blinky, your "Hello World!", on Arduino Zero
 
-Learn how to use packages from a default application repository of Mynewt to build your first *Hello World* application (Blinky) on a target board. Once built using the *newt* tool, this application will blink the LED lights on the target board.
-
-This tutorial describes how to run Mynewt OS on Arduino Zero. Follow these simple steps and your board will be blinking in no time!
+This tutorial shows you how to create, build and run the Blinky application on an Arduino Zero board.
 
 ### Prerequisites
-Ensure that you have met the following prerequisites before continuing with this tutorial:
-
+* Meet the prerequisites listed in [Project Blinky](/os/tutorials/blinky.md).
 * Have an Arduino Zero board.  
 Note: There are many flavors of Arduino. Make sure you are using an Arduino Zero. See below for the versions of Arduino Zero that are compatible with this tutorial.
-* Have Internet connectivity to fetch remote Mynewt components.
-* Have a computer to build a Mynewt application and connect to the board over USB.
-* Have a Micro-USB cable to connect the board and the computer.
-* Install the Newt tool and toolchains (See [Basic Setup](/os/get_started/get_started.md)).
-* Create a project space (directory structure) and populated it with the core code repository (apache-mynewt-core) or know how to as explained in [Creating Your First Project](/os/get_started/project_create).
-* Read the Mynewt OS [Concepts](/os/get_started/vocabulary.md) section. 
 
 This tutorial uses the Arduino Zero Pro board. The tutorial has been tested on the following three Arduino Zero boards - Zero, M0 Pro, and Zero-Pro.
 
@@ -349,18 +340,4 @@ debugger and restart the board.  The image you programmed will come up and run o
 the Arduino on the next boot!  
 
 <br>
-
-### Watch the LED Blink
-
-Congratulations! You have created an Mynewt application running on the
-Arduino Zero. The LED right next to the power LED should be blinking. It is toggled 
-by one task running on the Mynewt OS.   
-
-We have more fun tutorials for you to get your hands dirty. Be bold and try other 
-Blinky-like [tutorials](../tutorials/nRF52.md) or try enabling additional functionality 
-such as [remote comms](project-target-slinky.md) on the current board.
-
-If you see anything missing or want to send us feedback, please do so by signing up for 
-appropriate mailing lists on our [Community Page](../../community.md).
-
-Keep on hacking and blinking!
+You should see the LED blink!

--- a/docs/os/tutorials/blehci_project.md
+++ b/docs/os/tutorials/blehci_project.md
@@ -23,7 +23,7 @@ support native compiling to build the project this tutorial creates.
 
 ### Create a project
 
-Use the Newt tool to create a new project directory containing a skeletal Mynewt framework. Change into the newly created directory. Make sure the downloaded version is 0.9.0 or later.
+Use the Newt tool to create a new project directory containing a skeletal Mynewt framework. Change into the newly created directory. 
 
 ```
 $ newt new blehciproj 
@@ -32,11 +32,8 @@ Installing skeleton in blehciproj ...
 Project blehciproj  successfully created.
 $ cd mblehciproj 
 
-$ newt install -v 
+$ newt install
 apache-mynewt-core
-Downloading repository description for apache-mynewt-core... success!
-...
-apache-mynewt-core successfully installed version 0.9.0-none
 ```
 
 <br>
@@ -85,17 +82,19 @@ $ newt target show
 
 Then build the two targets.
 
-```
+```no-highlight
 $ newt build nrf52_boot
 <snip>
-App successfully built: ./bin/nrf52_boot/apps/boot/boot.elf
+Linking ~/dev/blehciproj/bin/targets/nrf52_boot/app/apps/boot/boot.elf
+Target successfully built: targets/nrf52_boot
+
 $ newt build myble2
-Compiling hci_common.c
-Compiling util.c
-Archiving nimble.a
-Compiling os.c
 <snip>
+Linking ~/dev/blehciproj/bin/targets/myble2/app/apps/blehci/blehci.elf
+Target successfully built: targets/myble2
+$
 ```
+
 
 <br>
 
@@ -103,20 +102,30 @@ Compiling os.c
 
 Generate a signed application image for the `myble2` target. The version number is arbitrary.
 
-```
+```no-highlight
 $ newt create-image myble2 1.0.0
-App image succesfully generated: ./bin/makerbeacon/apps/bletiny/bletiny.img
-Build manifest: ./bin/makerbeacon/apps/bletiny/manifest.json
+App image succesfully generated: ~/dev/blehciproj/bin/targets/myble2/app/apps/bletiny/bletiny.img
 ```
 
 <br>
 
-### Load the image
+### Load the bootloader and the application image
 
 Make sure the USB connector is in place and the power LED on the board is lit. Use the Power ON/OFF switch to reset the board after loading the image.
 
+Load the bootloader:
+
+```no-highlight
+$ newt load nrf52_boot
+Loading bootloader
+$
 ```
-$ newt -v load myble
+<br>
+Load the application image:
+```no-highlight
+$ newt load myble2
+Loading app image into slot 1
+$
 ```
 
 <br>

--- a/docs/os/tutorials/bletiny_project.md
+++ b/docs/os/tutorials/bletiny_project.md
@@ -1,4 +1,4 @@
-## Check stats on a BLE device
+## Check stats for a BLE Application  the NRF52 Board
 
 <br>
 
@@ -6,7 +6,7 @@ This tutorial explains how to run an example BLE app on a board and command it t
 
 <br>
 
-### Pre-Requisites
+### Prerequisites
 
 * Ensure you have installed [newt](../../newt/install/newt_mac.md) and that the 
 newt command is in your system path. 
@@ -23,18 +23,14 @@ support native compiling to build the project this tutorial creates.
 
 Use the Newt tool to create a new project directory containing a skeletal Mynewt framework. Change into the newly created directory.
 
-```
-$ newt new myapp1
+```no-highlight
+$ newt new myproj 
 Downloading project skeleton from apache/incubator-mynewt-blinky...
-Installing skeleton in myapp1...
-Project myapp1 successfully created.
-$ cd myapp1
+Installing skeleton in myproj...
+Project myproj successfully created.
+$ cd myproj
 
-$ newt install -v 
-apache-mynewt-core
-Downloading repository description for apache-mynewt-core... success!
-...
-apache-mynewt-core successfully installed version 0.7.9-none
+$ newt install 
 ```
 
 <br>
@@ -43,7 +39,7 @@ apache-mynewt-core successfully installed version 0.7.9-none
 
 You will create two targets - one for the bootloader, the other for the application.
 
-```
+```no-highlight
 $ newt target create myble
 Target targets/myble successfully created
 $ newt target create nrf52_boot
@@ -65,7 +61,7 @@ Define the targets further. Note that you are using the example app `bletiny` fo
 
 <br>
 
-```
+```no-highlight
 $ newt target set myble bsp=@apache-mynewt-core/hw/bsp/nrf52dk
 Target targets/myble successfully set target.bsp to @apache-mynewt-core/hw/bsp/nrf52dk
 $ newt target set myble app=@apache-mynewt-core/apps/bletiny
@@ -76,7 +72,7 @@ Target targets/myble successfully set target.build_profile to optimized
 
 Use the same `newt target set` command to set the following definition for the bootloader target -- again, make sure you use the correct value for the bsp based on which version of the board you have..
 
-```
+```no-highlight
 targets/nrf52_boot
     app=@apache-mynewt-core/apps/boot
     bsp=@apache-mynewt-core/hw/bsp/nrf52dk
@@ -85,7 +81,7 @@ targets/nrf52_boot
 
 You should have the following targets by the end of this step.
 
-```
+```no-highlight
 $ newt target show
 targets/my_blinky_sim
     app=apps/blinky
@@ -95,7 +91,6 @@ targets/myble
     app=@apache-mynewt-core/apps/bletiny
     bsp=@apache-mynewt-core/hw/bsp/nrf52dk
     build_profile=optimized
-    cflags=-DSTATS_NAME_ENABLE 
 targets/nrf52_boot
     app=@apache-mynewt-core/apps/boot
     bsp=@apache-mynewt-core/hw/bsp/nrf52dk
@@ -106,7 +101,7 @@ Since we're interested in seeing the stats, we'll need to enable the stats modul
 To do this, you'll need to create a configuration file `syscfg.yml` in the app directory. from the target definition above, you can see that the app is in `apache-mynewt-core/apps/bletiny`
 so that is where you'll put your configuration file. 
 
-```
+```no-highlight
 # Package: apps/bletiny
 
 syscfg.vals:
@@ -121,28 +116,52 @@ The first configuration value turns on the Shell Task, and we'll need this to ge
 
 Then build the two targets.
 
-```
-$ newt build nrf52_boot
-<snip>
-App successfully built: ./bin/nrf52_boot/apps/boot/boot.elf
-$ newt build myble
-Compiling hci_common.c
-Compiling util.c
-Archiving nimble.a
-Compiling os.c
-<snip>
-```
+Run the `newt build nrf52_boot` command to build the bootloader:
 
+```no-highlight
+Building target targets/nrf52_boot
+Compiling repos/apache-mynewt-core/boot/bootutil/src/image_ec.c
+Compiling repos/apache-mynewt-core/boot/bootutil/src/image_ec256.c
+Compiling repos/apache-mynewt-core/boot/bootutil/src/image_rsa.c
+Compiling repos/apache-mynewt-core/boot/bootutil/src/bootutil_misc.c
+Compiling repos/apache-mynewt-core/boot/bootutil/src/loader.c
+Compiling repos/apache-mynewt-core/apps/boot/src/boot.c
+
+Archiving sys_sysinit.a
+Archiving util_mem.a
+Linking ~/myproj/bin/targets/nrf52_boot/app/apps/boot/boot.elf
+Target successfully built: targets/nrf52_boot
+```
 <br>
+Run the `newt build myble` command to build the bletiny application:
+```no-highlight
+ newt build myble
+Building target targets/myble
+Compiling repos/apache-mynewt-core/encoding/base64/src/base64.c
+Compiling repos/apache-mynewt-core/encoding/base64/src/hex.c
+Compiling repos/apache-mynewt-core/hw/bsp/nrf52dk/src/hal_bsp.c
+Compiling repos/apache-mynewt-core/apps/bletiny/src/parse.c
+Compiling repos/apache-mynewt-core/apps/bletiny/src/misc.c
+Compiling repos/apache-mynewt-core/apps/bletiny/src/gatt_svr.c
+Compiling repos/apache-mynewt-core/apps/bletiny/src/cmd.c
+Compiling repos/apache-mynewt-core/apps/bletiny/src/main.c
 
+Archiving util_mem.a
+Linking ~/dev/myproj/bin/targets/myble/app/apps/bletiny/bletiny.elf
+Target successfully built: targets/myble
+
+```
+<br>
 ### Create the app image
 
-Generate a signed application image for the `myble` target. The version number is arbitrary.
+Run the `newt create-image myble 1.0.0` command to generate a signed application image for the `myble` target. The version number is arbitrary.
 
-```
-$ newt create-image myble 1.0.0
-App image succesfully generated: ./bin/makerbeacon/apps/bletiny/bletiny.img
-Build manifest: ./bin/makerbeacon/apps/bletiny/manifest.json
+```no-highlight
+$newt create-image myble 1.0.0
+Compiling bin/targets/myble/generated/src/myble-sysinit-app.c
+Archiving myble-sysinit-app.a
+Linking ~/dev/myproj/bin/targets/myble/app/apps/bletiny/bletiny.elf
+App image succesfully generated: ~/dev/myproj/bin/targets/myble/app/apps/bletiny/bletiny.img
 ```
 
 <br>
@@ -170,7 +189,7 @@ You may use any terminal emulation program to communicate with the board. This t
 
 
 ```
-$ minicom -D /dev/tty.usbserial-AJ03HAQQ -b 115200
+$ minicom -D /dev/tty.usbserial-1a12 -b 115200
 ```
 
 <br>
@@ -181,15 +200,15 @@ When the Minicom screen comes up, type in `?`
 Welcome to minicom 2.7
 
 OPTIONS: 
-Compiled on Nov 24 2015, 16:14:21.
-Port /dev/tty.usbserial-AJ03HAQQ, 09:57:17
+Compiled on Mar 18 2016, 04:59:47.
+Port /dev/tty.usbserial-1a12, 21:24:09
 
 Press Meta-Z for help on special keys
 
 ?
-4754:Commands:
-4754:     echo         ?    prompt     tasks  mempools      date
-4756:        b
+7471:Commands:
+7471:     stat      echo         ?    prompt     ticks     tasks 
+7474: mempools      date         b 
 ```
 
 <br>
@@ -214,13 +233,13 @@ This is just a counter kept by the MCU.
 Try the `tasks` command. 
 
 ```hl_lines="1"
-27365: > tasks
-Tasks:
-28330:  idle (prio: 255, tid: 0, lcheck: 0, ncheck: 0, flags: 0x0, ssize: 64, susage: 34, cswcnt: 233, tot_run_time: 28330ms)
-28333:  ble_ll (prio: 0, tid: 1, lcheck: 0, ncheck: 0, flags: 0x0, ssize: 80, susage: 60, cswcnt: 11, tot_run_time: 0ms)
-28336:  shell (prio: 1, tid: 2, lcheck: 0, ncheck: 0, flags: 0x0, ssize: 512, susage: 115, cswcnt: 18, tot_run_time: 0ms)
-28339:  bletiny (prio: 1, tid: 3, lcheck: 0, ncheck: 0, flags: 0x0, ssize: 512, susage: 138, cswcnt: 456, tot_run_time: 0ms)
-28342: >
+> tasks
+Tasks: 
+46682:    task pri tid  runtime      csw    stksz   stkuse   lcheck   ncheck fg
+46684:    idle 255   0    46683       99       64       31        0        0  0
+46686:    main 127   1        1       29      512      156        0        0  0
+46688:  ble_ll   0   2        0       12       80       58        0        0  0
+46691: > 
 ```
 
 <br>
@@ -228,40 +247,44 @@ Tasks:
 Try specifying a BLE related stat, for example `ble_ll`. You should see some HCI (Host Controller Interface) command counts. 
 
 ```hl_lines="1"
-241133: > stat ble_ll
+113136: > stat ble_ll
 hci_cmds: 11
-241888:hci_cmd_errs: 0
-241888:hci_events_sent: 11
-241890:bad_ll_state: 0
-241890:bad_acl_hdr: 0
-241891:no_bufs: 0
-241891:rx_adv_pdu_crc_ok: 0
-241892:rx_adv_pdu_crc_err: 0
-241893:rx_adv_bytes_crc_ok: 0
-241894:rx_adv_bytes_crc_err: 0
-241895:rx_data_pdu_crc_ok: 0
-241895:rx_data_pdu_crc_err: 0
-<snip>
+155545:hci_cmd_errs: 0
+155545:hci_events_sent: 11
+155547:bad_ll_state: 0
+155547:bad_acl_hdr: 0
+155548:no_bufs: 0
+155548:rx_adv_pdu_crc_ok: 0
+155549:rx_adv_pdu_crc_err: 0
+155550:rx_adv_bytes_crc_ok: 0
+155551:rx_adv_bytes_crc_err: 0
+155552:rx_data_pdu_crc_ok: 0
+
+    ...
+
+155564:scan_req_txf: 0
+155565:scan_req_txg: 0
+155565:scan_rsp_txg: 0
+155566: > 
 ```
 
 <br>
 
-For a more exciting output, try scanning your surroundings for BLE adverstisements. The HCI command shown below specifies a scan duration in ms, sets discovery mode to general (as opposed to limited), the filter to no-whitelist, and type of scan to passive. You should see some scan data flying by!
+For a more exciting output, try scanning your surroundings for BLE advertisements. The HCI command shown below specifies a scan duration in ms, scan to passive, and no duplicates.  You should see some scan data flying by!
+
 
 ```hl_lines="1"
-139088: > b scan dur=10000 disc=gen filt=no_wl type=passive
-...
-146055:received advertisement; event_type=0 addr_type=1 addr=6b:aa:49:b7:46:e6 length_data=24 rssi=-42 data=0x02:0x01:0x1a:0x14:0xff:0x4c:0x00:0x01:0x00:0x00:0x00:0x00:0x04:0x00:0x00:0x00:0x00:0x00:0x00:0x00:0x00:0x00:0x00:0x00 fields:
-146061:    flags=0x1a
-146062:    mfg_data=0x4c:0x00:0x01:0x00:0x00:0x00:0x00:0x04:0x00:0x00:0x00:0x00:0x00:0x00:0x00:0x00:0x00:0x00:0x00
-146065:
-146065:received advertisement; event_type=0 addr_type=0 addr=ac:bc:32:ac:4f:e4 length_data=11 rssi=-36 data=0x02:0x01:0x06:0x07:0xff:0x4c:0x00:0x10:0x02:0x0b:0x00 fields:
-146069:    flags=0x06
-146070:    mfg_data=0x4c:0x00:0x10:0x02:0x0b:0x00
-146071:
-146072:scanning finished
-...
-<snip>
+b scan dur=10000 passive=1 nodups=1
+37266:[ts=291140616ssb, mod=4 level=1] GAP procedure initiated: discovery; own_as
+
+37641:
+38256:received advertisement; event_type=0 rssi=-48 addr_type=1 addr=59:cc:3d:a3:
+38261:    flags=0x1a:
+38261:        General discoverable mode
+38262:    uuids16(complete)=0x1802 
+38263:    name(complete)=Find Me
+38264:
+38551:scanning finished
 ```
 
 <br>
@@ -271,42 +294,50 @@ If you're still not seeing any output from the device, try running the debugger 
 <br>
 
 ```
-$ newt debug myble
-Debugging ./bin/myble/apps/bletiny/bletiny.elf
-GNU gdb (GNU Tools for ARM Embedded Processors) 7.6.0.20140731-cvs
-Copyright (C) 2013 Free Software Foundation, Inc.
-
+$newt debug myble
+[~/dev/myproj/repos/apache-mynewt-core/hw/bsp/nrf52dk/nrf52dk_debug.sh ~/dev/myproj/repos/apache-mynewt-core/hw/bsp/nrf52dk ~/dev/wanda/dev/myproj/bin/targets/myble/app/apps/bletiny/bletiny]
+~/dev/myproj/repos/apache-mynewt-core/hw/scripts/common.sh: line 38: [: =: unary operator expected
+Debugging ~/dev/myproj/bin/targets/myble/app/apps/bletiny/bletiny.elf
+GNU gdb (GNU Tools for ARM Embedded Processors) 7.8.0.20150604-cvs
+Copyright (C) 2014 Free Software Foundation, Inc.
 License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
 This is free software: you are free to change and redistribute it.
 There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
 and "show warranty" for details.
 This GDB was configured as "--host=x86_64-apple-darwin10 --target=arm-none-eabi".
+Type "show configuration" for configuration details.
 For bug reporting instructions, please see:
-<http://www.gnu.org/software/gdb/bugs/>...
-Reading symbols from ./bin/myble/apps/bletiny/bletiny.elf...done.
-0x00002f08 in ?? ()
+<http://www.gnu.org/software/gdb/bugs/>.
+Find the GDB manual and other documentation resources online at:
+<http://www.gnu.org/software/gdb/documentation/>.
+For help, type "help".
+Type "apropos word" to search for commands related to "word"...
+Reading symbols from ~/dev/myproj/bin/targets/myble/app/apps/bletiny/bletiny.elf...done.
+os_tick_idle (ticks=1920)
+    at repos/apache-mynewt-core/hw/mcu/nordic/nrf52xxx/src/hal_os_tick.c:200
+200    if (ticks > 0) {
 (gdb) monitor reset
 Resetting target
 (gdb) c
 Continuing.
 ^C
 Program received signal SIGTRAP, Trace/breakpoint trap.
-os_tick_idle (ticks=1000) at hal_os_tick.c:117
-117	    if (ticks > 0) {
+os_tick_idle (ticks=1907)
+    at repos/apache-mynewt-core/hw/mcu/nordic/nrf52xxx/src/hal_os_tick.c:200
+200    if (ticks > 0) {
 (gdb) p g_os_time
-$1 = 37991
+$1 = 13
 (gdb) c
 Continuing.
 ^C
 Program received signal SIGTRAP, Trace/breakpoint trap.
-os_tick_idle (ticks=1000) at hal_os_tick.c:117
-117	    if (ticks > 0) {
+os_tick_idle (ticks=1920)
+    at repos/apache-mynewt-core/hw/mcu/nordic/nrf52xxx/src/hal_os_tick.c:200
+200    if (ticks > 0) {
 (gdb) p g_os_time
-$2 = 51888
-(gdb) c
-Continuing.
+$2 = 6611
+(gdb) 
 ```
-
 <br>
 
 You should see the g_os_time advancing as above, as each os time tick is 1ms. If the system ticks aren't advancing, then nothing's actually running.

--- a/docs/os/tutorials/blinky.md
+++ b/docs/os/tutorials/blinky.md
@@ -1,0 +1,47 @@
+## Blinky, your "Hello World!" on a Target Board
+The set of Blinky tutorials show you how to create, build, and run  a "Hello World" application that blinks a LED on the various target boards that Mynewt supports. The tutorials use the same Blinky application from the [Creating Your First Project](/os/get_started/project_create) tutorial.  
+
+### Objective
+
+Learn how to use packages from a default application repository of Mynewt to build your first *Hello World* application (Blinky) on a target board. Once built using the *newt* tool, this application will blink a LED light on the target board.
+
+###Available Tutorials
+Tutorials are available for the following boards:
+
+* [Blinky on an Arduino Zero](/os/tutorials/arduino_zero.md)
+* [Blinky on an Arduino Primo](/os/tutorials/blinky_primo.md)
+* [Blinky on an Olimex](/os/tutorials/olimex.md)
+* [Blinky on a nRF52](/os/tutorials/nRF52.md)
+* [Blinky on a RedBear Nano 2](/os/tutorials/rbnano2.md)
+
+We also have a tutorial that shows you how to add [Console and Shell to the Blinky Application](/os/tutorials/blinky_console.md).
+<br>
+### Prerequisites
+Ensure that you meet the following prerequisites before continuing with one of the tutorials. 
+
+* Have Internet connectivity to fetch remote Mynewt components.
+* Have a computer to build a Mynewt application and connect to the board over USB.
+* Have a Micro-USB cable to connect the board and the computer.
+* Install the Newt tool and toolchains (See [Basic Setup](/os/get_started/get_started.md)).
+* Install either the Jlink or OpenOCD debugger.
+* Create a project space (directory structure) and populate it with the core code repository (apache-mynewt-core) or know how to as explained in [Creating Your First Project](/os/get_started/project_create).
+* Read the Mynewt OS [Concepts](/os/get_started/vocabulary.md) section. 
+<br>
+###Overview of Steps
+These are the general steps to create, load and run the Blinky application on your board:
+
+* Create a project.
+* Define the bootloader and Blinky application targets for the board.
+* Build the bootloader target.
+* Build the Blinky application target and create an application image.
+* Connect to the board.
+* Load to bootloader onto the board.
+* Load to Blinky application image onto the board.
+* See the LED on your board blink.
+
+<br>
+
+After you try the Blinky application on your boards, checkout out other tutorials to enable additional functionality such as [remote comms](project-slinky.md) on the current board.
+
+If you see anything missing or want to send us feedback, please sign up for 
+appropriate mailing lists on our [Community Page](../../community.md).

--- a/docs/os/tutorials/blinky_console.md
+++ b/docs/os/tutorials/blinky_console.md
@@ -49,14 +49,14 @@ syscfg.vals:
 
 <br>
 ### Use the OS Default Event Queue to Process Blinky Timer and Shell Events
-Mynewt creates a default task that executes the application `main()` function. It also creates an OS default event queue that packages can use to queue their events.   Shell uses the OS default event queue for Shell events,  and `main()` can process the events in the context of the default task. 
+Mynewt creates a main task that executes the application `main()` function. It also creates an OS default event queue that packages can use to queue their events.   Shell uses the OS default event queue for Shell events,  and `main()` can process the events in the context of the main task. 
 
 Blinky's main.c is very simple. It only has a `main()` function that executes an infinite loop to toggle the LED and sleep for one second.  We will modify blinky:
 
 * To use os_callout to generate a timer event every one second instead of sleeping.  The timer events are added to the OS default event queue.
 * To process events from the OS default event queue inside the infinite loop in `main()`.
 
-This allows the default task to process both Shell events and the timer events to toggle the LED from the OS default event queue.
+This allows the main task to process both Shell events and the timer events to toggle the LED from the OS default event queue.
 
 <br>
 ### Modify main.c
@@ -170,7 +170,7 @@ Tutorial for more information on setting up your serial communication.
 
 ###Communicate with the Application
 
-Once you have a connection set up, run ```minicom -D /dev/tty.usbmodem<port> -b 115200``` to connect to the application console.
+Once you have a connection set up, run ```minicom -D /dev/tty.usbserial<port> -b 115200``` to connect to the application console.
     
 To test and make sure that the Shell is running, first just hit <return>:
     

--- a/docs/os/tutorials/blinky_console.md
+++ b/docs/os/tutorials/blinky_console.md
@@ -1,14 +1,12 @@
 ##Enabling The Console and Shell for Blinky
 
-<br>
-
-This tutorial explains how to add the Console and Shell task to the blinky application so that you can interact with it over a serial line connection.
-
+This tutorial shows you how to add the Console and Shell to the Blinky application and interact with it over a serial line connection.
 <br>
 
 ### Prerequisites
 
 * Work through one of the Blinky Tutorials to create and build a Blinky application for one of the boards.
+* Have a [serial setup](/os/get_started/serial_access.md).
 
 <br>
 

--- a/docs/os/tutorials/blinky_primo.md
+++ b/docs/os/tutorials/blinky_primo.md
@@ -1,41 +1,23 @@
 ## Blinky, your "Hello World!", on Arduino Primo
 
-<br>
-
-### Objective
-
-Learn how to use packages from a default application repository of Mynewt to build your first *Hello World* application (Blinky) on a target board. Once built using the *newt* tool, this application will blink the LED lights on the target board.
-
-Create a project with a simple app that blinks an LED on the Arduino Primo board.  Download the application to the target and watch it blink!
+This tutorial shows you how to create, build, and run the Blinky application on an Arduino Primo board.
 
 Note that the Mynewt OS will run on the nRF52 chip in the Arduino Primo board. However, the board support package for the Arduino Primo is different from the nRF52 dev kit board support package.
-
 <br>
-
 ### Prerequisites
-Ensure that you have met the following prerequisites before continuing with this tutorial:
 
-* Have an Arduino Primo
-* Have Internet connectivity to fetch remote Mynewt components.
-* Have a computer to build a Mynewt application and connect to the` board over USB.
-* Have a Micro-USB cable to connect the board and the computer.
-* Install the Newt tool and toolchains (See [Basic Setup](/os/get_started/get_started.md)).
-* Create a project space (directory structure) and populated it with the core code repository (apache-mynewt-core) or know how to as explained in [Creating Your First Project](/os/get_started/project_create).
-* Read the Mynewt OS [Concepts](/os/get_started/vocabulary.md) section.
-* Install a debugger - choose one of the two options below. Option 1 requires additional hardware but very easy to set up. Option 2 is free software but not as simple as Option 1.
+* Meet the the prerequisites listed in [Project Blinky](/os/tutorials/blinky.md).
+* Have an Arduino Primo board.
+* Install a debugger choose one of the two options below:  Option 1 requires additional hardware but very easy to set up. 
 
 <br>
-
 ##### Option 1
-
 * [Segger J-Link Debug Probe](https://www.segger.com/jlink-debug-probes.html) - any model (this tutorial has been tested with J-Link EDU and J-Link Pro)
 * [J-Link 9 pin Cortex-M Adapter](https://www.segger.com/jlink-adapters.html#CM_9pin) that allows JTAG, SWD and SWO connections between J-Link and Cortex M based target hardware systems
 * Install the [Segger JLINK Software and documentation pack](https://www.segger.com/jlink-software.html). 
 
-
 ##### Option 2
-
- No additional hardware is required but a version of OpenOCD 0.10.0 that is currently in development needs to be installed. A patch for the nRF52 has been applied to the OpenOCD code in development and a tarball has been made available for download [here](downloads/openocd-wnrf52.tgz). Untar it. From the top of the directory tree ("openocd-code-89bf96ffe6ac66c80407af8383b9d5adc0dc35f4"), build it using the following configuration:
+No additional hardware is required but a version of OpenOCD 0.10.0 that is currently in development needs to be installed. A patch for the nRF52 has been applied to the OpenOCD code in development and a tarball has been made available for download [here](downloads/openocd-wnrf52.tgz). Untar it. From the top of the directory tree ("openocd-code-89bf96ffe6ac66c80407af8383b9d5adc0dc35f4"), build it using the following configuration:
 
 ```
 $./configure --enable-cmsis-dap --enable-openjtag_ftdi --enable-jlink --enable-stlink
@@ -50,9 +32,9 @@ Licensed under GNU GPL v2
 For bug reports, read
     http://openocd.org/doc/doxygen/bugs.html
 ```
+
 You can now use openocd to upload to Arduino Primo board via the USB port itself.
 
-<br>
 ### Create a Project  
 Create a new project if you do not have an existing one.  You can skip this step and proceed to [create the targets](#create_targets) if you already created a project.
 
@@ -252,20 +234,3 @@ warning: Source file is more recent than executable.
 (gdb) mon nrf52 mass_erase
 ```
 <br>
-
-
-### Conclusion
-
-You have created, setup, compiled, loaded, and ran your first mynewt application
-for an Arduino Primo board.
-
-We have more fun tutorials for you to get your hands dirty. Be bold and work on the OS with tutorials on [writing a test suite](unit_test.md) or try enabling additional functionality such as [remote comms](project-target-slinky.md) or [Bluetooth Low Energy](bletiny_project.md) on your current board.
-
-If you see anything missing or want to send us feedback, please do so by signing up for appropriate mailing lists on our [Community Page](../../community.md).
-
-Keep on hacking and blinking!
-
-
-
-
-

--- a/docs/os/tutorials/nRF52.md
+++ b/docs/os/tutorials/nRF52.md
@@ -1,12 +1,6 @@
 ## Blinky, your "Hello World!", on nRF52
-
+This tutorial shows you how to create, build, and run the Blinky application on the nRF52 board.
 <br>
-
-### Objective
-
-Learn how to use packages from a default application repository of Mynewt to build your first *Hello World* application (Blinky) on a target board. Once built using the *newt* tool, this application will blink the LED lights on the target board.
-
-Create a project with a simple application that blinks an LED on the nRF52 board from Nordic Semiconductors.  Download the application to the target and watch it blink!
 
 Note that there are several versions of the nRF52 in the market. The boards tested with this tutorial are listed under "Prerequisites".
 
@@ -14,18 +8,10 @@ Note that there are several versions of the nRF52 in the market. The boards test
 
 ### Prerequisites
 
-Ensure that you have met the following prerequisites before continuing with this tutorial:
-
+* Meet the prerequisites listed in [Project Blinky](/os/tutorials/blinky.md).
 * Have a nRF52 Development Kit (one of the following)
     * Dev Kit from Nordic - PCA 10040
     * Eval Kit from Rigado - BMD-300-EVAL-ES
-* Have Internet connectivity to fetch remote Mynewt components.
-* Have a computer to build a Mynewt application and connect to the board over USB.
-* Have a Micro-USB cable to connect the board and the computer.
-* Install the Newt tool and toolchains (See [Basic Setup](/os/get_started/get_started.md)).
-* Install the [Segger JLINK package]( https://www.segger.com/jlink-software.html) to load your project on the board.
-* Create a project space (directory structure) and populated it with the core code repository (apache-mynewt-core) or know how to as explained in [Creating Your First Project](/os/get_started/project_create).
-* Read the Mynewt OS [Concepts](/os/get_started/vocabulary.md) section.
 
 This tutorial uses the Nordic nRF52-DK board.
 
@@ -205,19 +191,3 @@ Erasing done.
 J-Link>exit
 $
 ```
-
-
-### Conclusion
-
-You have created, setup, compiled, loaded, and ran your first mynewt application for an nrf52 board.
-
-We have more fun tutorials for you to get your hands dirty. Be bold and work on the OS with tutorials on [writing a test suite](unit_test.md) or try enabling additional functionality such as [remote comms](project-target-slinky.md) or [Bluetooth Low Energy](bletiny_project.md) on your current board.
-
-If you see anything missing or want to send us feedback, please do so by signing up for appropriate mailing lists on our [Community Page](../../community.md).
-
-Keep on hacking and blinking!
-
-
-
-
-

--- a/docs/os/tutorials/nrf52_adc.md
+++ b/docs/os/tutorials/nrf52_adc.md
@@ -65,12 +65,12 @@ project.repositories:
 #
 repository.apache-mynewt-core:
     type: github
-    vers: 0-dev
+    vers: 1-dev
     user: apache
     repo: incubator-mynewt-core
 repository.mynewt_nordic:
     type: github
-    vers: 0-latest
+    vers: 1-latest
     user: runtimeinc
     repo: mynewt_nordic
 ```

--- a/docs/os/tutorials/olimex.md
+++ b/docs/os/tutorials/olimex.md
@@ -1,30 +1,14 @@
 ## Blinky, your "Hello World!", on Olimex
 
-### Objective
-
-Learn how to use packages from a default application repository of Mynewt to build your first *Hello World* application (Blinky) on a target board. Once built using the *newt* tool, this application will blink the LED lights on the target board. Fun stuff!
-
-This tutorial shows you how to create a blinky application for the Olimex board. It also shows you how to load the application onto the board's flash memory and run the application.
-
+This tutorial shows you how to create, build, and run the Blinky application on an Olimex STM32-E407 board.
 <br>
-
 ### Prerequisites
-Ensure that you have met the following prerequisites before continuing with this tutorial:
 
+* Meet the prerequisites listed in [Project Blinky](/os/tutorials/blinky.md).
 * Have a STM32-E407 development board from Olimex. 
 * Have a ARM-USB-TINY-H connector with JTAG interface for debugging ARM microcontrollers (comes with the ribbon cable to hook up to the board)
-* Have Internet connectivity to fetch remote Mynewt components.
-* Have a computer to build a Mynewt application and connect to the board over USB.
 * Have a USB A-B type cable to connect the debugger to your computer.
-* Have a USB Micro-A cable to connect your computer to the board.
-* Install the Newt tool and toolchains (See [Basic Setup](/os/get_started/get_started.md)).
-* Create a project space (directory structure) and populated it with the core code repository (apache-mynewt-core) or know how to as explained in [Creating Your First Project](/os/get_started/project_create).
-* Read the Mynewt OS [Concepts](/os/get_started/vocabulary.md) section.
-
-
 <br>
-
-
 ### Create a Project
 Create a new project if you do not have an existing one.  You can skip this step and proceed to [create the targets](#create_targets) if you already created a project.
 
@@ -224,13 +208,3 @@ Let's double check that it is indeed booting from flash and making the LED blink
     (0x08000020: ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff         
     (gdb) monitor flash info 0
 ```
-
-### Conclusion
-
-Congratulations! You have now tried out a project on actual hardware. If this is your first time to embedded systems, this must feel like the best hands-on and low-level "Hello World" program ever.
-
-Good, we have more fun tutorials for you to get your hands dirty. Be bold and try other Blinky-like [tutorials](../tutorials/nRF52.md) or try enabling additional functionality such as [remote comms](project-target-slinky.md) on the current board.
-
-If you see anything missing or want to send us feedback, please do so by signing up for appropriate mailing lists on our [Community Page](../../community.md).
-
-Keep on hacking and blinking!

--- a/docs/os/tutorials/project-nrf52-slinky.md
+++ b/docs/os/tutorials/project-nrf52-slinky.md
@@ -1,34 +1,9 @@
 ## Project Slinky using the Nordic nRF52 Board
-
-
-<br>
-
-The goal of this tutorial is to enable and demonstrate remote communications with a Mynewt application running on a device via newt manager (newtmgr). It uses the "Slinky" sample application that is included in the apache-mynewt-core/apps directory and the Nordic nRF52-DK board.
-
-If you have an existing project that has a different application and you wish to add newtmgr functionality to it, check out the [Enable newtmgr in any app](add_newtmgr.md) tutorial.
+This tutorial shows you how to create, build and run the Slinky application and communicate with newtmgr for a Nordic nRF52 board.
 
 ### Prerequisites
-
-Ensure that you have met the following prerequisites before continuing with this tutorial:
-
+* Meet the prerequisites listed in [Project Slinky](/os/tutorials/project-slinky.md).  
 * Have a Nordic nRF52-DK board.  
-* Have Internet connectivity to fetch remote Mynewt components.
-* Have a computer to build a Mynewt application and connect to the board over USB.
-* Have a Micro-USB cable to connect the board and the computer.
-* Have a [Serial Port Setup](/os/get_started/serial_access.md). 
-* Install the newt tool and the toolchains (See [Basic Setup](/os/get_started/get_started.md)).
-* Install the [newtmgr tool](../../newtmgr/installing/). 
-* Create a project space (directory structure) and populated it with the core code repository (apache-mynewt-core) or know how to as explained in [Creating Your First Project](/os/get_started/project_create).
-* Read the Mynewt OS [Concepts](/os/get_started/vocabulary.md) section.
-
-### Overview of Steps
-
-* Install dependencies
-* Define targets using the newt tool
-* Build executables for the targets using the newt tool
-* Set up serial connection with the targets
-* Create a connection profile using the newtmgr tool
-* Use the newtmgr tool to communicate with the targets
 
 ### Create a New Project
 Create a new project if you do not have an existing one.  You can skip this step and proceed to [create the targets](#create_targets) if you already have a project created or completed the [Sim Slinky](project-slinky.md) tutorial. 

--- a/docs/os/tutorials/project-sim-slinky.md
+++ b/docs/os/tutorials/project-sim-slinky.md
@@ -1,0 +1,119 @@
+## Project Sim Slinky  
+
+This tutorial shows you how to create, build and run the Slinky application and communicate with newtmgr for a simulated device.
+
+<br>
+### Prerequisites
+
+Meet the prerequisites listed in [Project Slinky](/os/tutorials/project-slinky.md).
+
+### Creating a new project
+
+Instructions for creating a project are located in the [Basic Setup](../get_started/project_create/) section of the [Mynewt Documentation](../introduction/)
+
+We will list only the steps here for brevity.  We will name the project `slinky`.
+
+```no-highlight
+$ newt new slinky
+Downloading project skeleton from apache/incubator-mynewt-blinky...
+...
+Installing skeleton in slink...
+Project slinky successfully created
+$ cd slinky
+$newt install
+apache-mynewt-core
+```
+
+### Setting up your target build
+
+Create a target for `slinky` using the native bsp. We will list only the steps and suppress the tool output here for brevity.
+
+```no-highlight
+    $ newt target create sim_slinky
+    $ newt target set sim_slinky bsp=@apache-mynewt-core/hw/bsp/native
+    $ newt target set sim_slinky build_profile=debug
+    $ newt target set sim_slinky app=@apache-mynewt-core/apps/slinky
+```
+
+### Building Your target
+
+To build your target, use `newt build`.  When complete, an executable file
+is created.
+
+```no-highlight
+    $ newt build sim_slinky 
+    Building target targets/sim_slinky
+    Compiling repos/apache-mynewt-core/boot/bootutil/src/image_ec256.c
+    Compiling repos/apache-mynewt-core/boot/bootutil/src/image_rsa.c
+    Compiling repos/apache-mynewt-core/boot/bootutil/src/image_ec.c
+    Compiling repos/apache-mynewt-core/boot/split/src/split.c
+    Compiling repos/apache-mynewt-core/boot/bootutil/src/image_validate.c
+    Compiling repos/apache-mynewt-core/boot/bootutil/src/loader.c
+    Compiling repos/apache-mynewt-core/boot/bootutil/src/bootutil_misc.c
+    Compiling repos/apache-mynewt-core/crypto/mbedtls/src/aesni.c
+    Compiling repos/apache-mynewt-core/crypto/mbedtls/src/aes.c
+    Compiling repos/apache-mynewt-core/boot/split/src/split_config.c
+    Compiling repos/apache-mynewt-core/apps/slinky/src/main.c
+
+              ...
+
+    Archiving util_crc.a
+    Archiving util_mem.a
+    Linking ~/dev/slinky/bin/targets/sim_slinky/app/apps/slinky/slinky.elf
+    Target successfully built: targets/sim_slinky
+
+```
+
+### Run the target
+
+Run the executable you have build for the simulated environment. The serial port name on which the simulated target is connected is shown in the output when mynewt slinky starts.
+
+```no-highlight
+    $ ~/dev/slinky/bin/targets/sim_slinky/app/apps/slinky/slinky.elf
+    uart0 at /dev/ttys005
+```
+
+<br>
+
+In this example, the slinky app opened up a com port `/dev/ttys005` for communications with newtmgr. 
+
+**NOTE:** This application will block. You will need to open a new console (or execute this in another console) to continue the tutorial.*
+
+<br>
+
+### Setting up a connection profile
+
+You will now set up a connection profile using `newtmgr` for the serial port connection and start communicating with the simulated remote device.
+
+```no-highlight
+    $ newtmgr conn add sim1 type=serial connstring=/dev/ttys005
+    Connection profile sim1 successfully added
+    $ newtmgr conn show
+    Connection profiles: 
+      sim1: type=serial, connstring='/dev/ttys005'
+```
+
+### Executing newtmgr commands with the target
+
+You can now use connection profile `sim1` to talk to the running sim_slinky.
+As an example, we will query the running mynewt OS for the usage of its 
+memory pools.  
+
+```no-highlight
+    $ newtmgr -c sim1 mpstats
+    Return Code = 0
+                            name blksz  cnt free  min
+                          msys_1   292   12   10   10
+
+```
+
+As a test command, you can send an arbitrary string to the target and it
+will echo that string back in a response to newtmgr.
+
+```no-highlight
+    $ newtmgr -c sim1 echo "Hello Mynewt"
+    Hello Mynewt
+```
+
+In addition to these, you can also examine running tasks, statistics, 
+logs, image status (not on sim), and configuration.

--- a/docs/os/tutorials/project-slinky.md
+++ b/docs/os/tutorials/project-slinky.md
@@ -1,142 +1,36 @@
-## Project Sim Slinky  
+## Project Slinky  
 
+The goal of the project is to use a sample application called "Slinky" included in the Mynewt repository to enable remote communications with a device running the Mynewt OS. The protocol for remote communications is called newt manager (newtmgr). 
 
-<br>
+If you have an existing project using a target that does not use the Slinky application and you wish to add newtmgr functionality to it, check out the tutorial titled [Enable newtmgr in any app](add_newtmgr.md). 
 
-The goal of the project is to use a sample app called "Slinky" included in the Mynewt repository to enable remote communications with a device running the Mynewt OS. The protocol for remote communications is called newt manager (newtmgr). In this tutorial we will create a target for a simulated device and define it with the sample app "Slinky". 
+###Available Tutorials
+Tutorials are available for the following boards:
 
-If you have an existing project using a target that does not use the Slinky app and you wish to add newtmgt functonality to it, check out the tutorial titled [Enable newtmgr in any app](add_newtmgr.md). 
-
+* [Slinky on a simulated device](/os/tutorials/project-sim-slinky).
+* [Slinky on a nRF52](/os/tutorials/project-nrf52-slinky).
+* [Slinky on an Olimex](/os/tutorials/project-stm32-slinky).
 <br>
 ### Prerequisites
 
-Ensure that you have met the following prerequisites before continuing with this tutorial:
+Ensure that you meet the following prerequisites before continuing with this tutorial:
 
 * Have Internet connectivity to fetch remote Mynewt components.
-* Have a computer to build a Mynewt application.
+* Have a computer to build a Mynewt application and connect to the board over USB.
+* Have a Micro-USB cable to connect the board and the computer.
+* Have a [serial port setup](/os/get_started/serial_access.md).
 * Install the newt tool and the toolchains (See [Basic Setup](/os/get_started/get_started.md)).
 * Install the [newtmgr tool](../../newtmgr/installing/).
+* Create a project space (directory structure) and populated it with the core code repository (apache-mynewt-core) or kn
+ow how to as explained in [Creating Your First Project](/os/get_started/project_create).
 * Read the Mynewt OS [Concepts](/os/get_started/vocabulary.md) section.
 
-### Overview of steps
+### Overview of Steps
 
-* Install dependencies
-* Define a target using the newt tool
-* Build executables for the targets using the newt tool
-* Set up serial connection with the targets 
-* Create a connection profile using the newtmgr tool
-* Use the newtmgr tool to communicate with the targets
-
-### Creating a new project
-
-Instructions for creating a project are located in the [Basic Setup](../get_started/project_create/) section of the [Mynewt Documentation](../introduction/)
-
-We will list only the steps here for brevity.  We will name the project
-`slinky`.
-
-```no-highlight
-    $ newt new slinky
-    Downloading project skeleton from apache/incubator-mynewt-blinky...
-    ...
-    Installing skeleton in slink...
-    Project slink successfully created
-    $ cd slinky
-    $ newt install -v
-    Downloading repository description for apache-mynewt-core... success!
-    ...
-    Repos successfully installed
-```
-
-### Setting up your target build
-
-Create a target for `slinky` using the native bsp. We will list only the steps and suppress the tool output here for brevity.
-
-```no-highlight
-    $ newt target create sim_slinky
-    $ newt target set sim_slinky bsp=@apache-mynewt-core/hw/bsp/native
-    $ newt target set sim_slinky build_profile=debug
-    $ newt target set sim_slinky app=@apache-mynewt-core/apps/slinky
-```
-
-### Building Your target
-
-To build your target, use `newt build`.  When complete, an executable file
-is created.
-
-```no-highlight
-    $ newt build sim_slinky 
-    Building target targets/sim_slinky
-    Compiling repos/apache-mynewt-core/boot/bootutil/src/image_ec256.c
-    Compiling repos/apache-mynewt-core/boot/bootutil/src/image_rsa.c
-    Compiling repos/apache-mynewt-core/boot/bootutil/src/image_ec.c
-    Compiling repos/apache-mynewt-core/boot/split/src/split.c
-    Compiling repos/apache-mynewt-core/boot/bootutil/src/image_validate.c
-    Compiling repos/apache-mynewt-core/boot/bootutil/src/loader.c
-    Compiling repos/apache-mynewt-core/boot/bootutil/src/bootutil_misc.c
-    Compiling repos/apache-mynewt-core/crypto/mbedtls/src/aesni.c
-    Compiling repos/apache-mynewt-core/crypto/mbedtls/src/aes.c
-    Compiling repos/apache-mynewt-core/boot/split/src/split_config.c
-    Compiling repos/apache-mynewt-core/apps/slinky/src/main.c
-
-              ...
-
-    Archiving util_crc.a
-    Archiving util_mem.a
-    Linking ~/dev/slinky/bin/targets/sim_slinky/app/apps/slinky/slinky.elf
-    Target successfully built: targets/sim_slinky
-
-```
-
-### Run the target
-
-Run the executable you have build for the simulated environment. The serial port name on which the simulated target is connected is shown in the output when mynewt slinky starts.
-
-```no-highlight
-    $ ~/dev/slinky/bin/targets/sim_slinky/app/apps/slinky/slinky.elf
-    uart0 at /dev/ttys005
-```
-
-<br>
-
-In this example, the slinky app opened up a com port `/dev/ttys005` for communications with newtmgr. 
-
-**NOTE:** This application will block. You will need to open a new console (or execute this in another console) to continue the tutorial.*
-
-<br>
-
-### Setting up a connection profile
-
-You will now set up a connection profile using `newtmgr` for the serial port connection and start communicating with the simulated remote device.
-
-```no-highlight
-    $ newtmgr conn add sim1 type=serial connstring=/dev/ttys005
-    Connection profile sim1 successfully added
-    $ newtmgr conn show
-    Connection profiles: 
-      sim1: type=serial, connstring='/dev/ttys005'
-```
-
-### Executing newtmgr commands with the target
-
-You can now use connection profile `sim1` to talk to the running sim_slinky.
-As an example, we will query the running mynewt OS for the usage of its 
-memory pools.  
-
-```no-highlight
-    $ newtmgr -c sim1 mpstats
-    Return Code = 0
-                            name blksz  cnt free  min
-                          msys_1   292   12   10   10
-
-```
-
-As a test command, you can send an arbitrary string to the target and it
-will echo that string back in a response to newtmgr.
-
-```no-highlight
-    $ newtmgr -c sim1 echo "Hello Mynewt"
-    Hello Mynewt
-```
-
-In addition to these, you can also examine running tasks, statistics, 
-logs, image status (not on sim), and configuration.
+* Install dependencies.
+* Define the bootloader and Slinky application target for the target board.
+* Build the bootloader target.
+* Build the Slinky application target and create an application image.
+* Set a up serial connection with the targets.
+* Create a connection profile using the newtmgr tool.
+* Use the newtmgr tool to communicate with the targets.

--- a/docs/os/tutorials/project-stm32-slinky.md
+++ b/docs/os/tutorials/project-stm32-slinky.md
@@ -1,34 +1,13 @@
-## Project Slinky Using STM32 Board
+## Project Slinky Using Olimex Board
 
-The goal of the project is to enable and demonstrate remote communications with the Mynewt OS via newt manager (newtmgr) by leveraging a sample app "Slinky" included under the /apps directory in the repository. In this project we will define a target for the STM32-E407 board and assign the app "Slinky" to it.
-
-If you have an existing project that has a different application and you wish to add newtmgr functionality to it, check out the [Enable newtmgr in any app](add_newtmgr.md) tutorial.
-
+This tutorial shows you how to create, build and run the Slinky application and communicate with newtmgr for an Olimex STM-E407 board.
 <br>
-
-
 ###Prerequisites
-Ensure that you have met the following prerequisites before continuing with this tutorial:
-
+* Meet the prerequisites listed in [Project Slinky](/os/tutorials/project-slinky.md).
 * Have a STM32-E407 development board from Olimex. 
 * Have a ARM-USB-TINY-H connector with JTAG interface for debugging ARM microcontrollers (comes with the ribbon cable to hook up to the board)
+* Have a USB A-B type cable to connect the debugger to your computer. 
 * Have a USB to TTL Serial Cable with female wiring harness.
-* Have a USB Micro-A cable to connect your computer to the board.
-* Have Internet connectivity to fetch remote Mynewt components.
-* Have a computer to build a Mynewt application and connect to the board over USB.
-* Install the newt tool and the toolchains (See Basic Setup).
-* Install the newtmgr tool.
-* Create a project space (directory structure) and populated it with the core code repository (apache-mynewt-core) or know how to as explained in Creating Your First Project.
-* Read the Mynewt OS Concepts section.
-
-### Overview of Steps
-
-* Install dependencies
-* Define a target using the newt tool
-* Build executables for the targets using the newt tool
-* Set up serial connection with the targets
-* Create a connection profile using the newtmgr tool
-* Use the newtmgr tool to communicate with the targets
 
 ### Create a New Project
 Create a new project if you do not have an existing one.  You can skip this step and proceed to [create the targets](#create_targets) if you already have a project created or completed the [Sim Slinky](project-slinky.md) tutorial.

--- a/docs/os/tutorials/rbnano2.md
+++ b/docs/os/tutorials/rbnano2.md
@@ -1,25 +1,12 @@
 ## Blinky, your "Hello World!", on RedBear Nano 2
 
-<br>
-
-### Objective
-
-Learn how to use packages from a default application repository of Mynewt to build your first *Hello World* application (Blinky) on a target board. Once built using the *newt* tool, this application will blink the LED lights on the target board.
-
-Create a project with a simple application that blinks an LED on a RedBear Nano 2 board.  Download the application to the target and watch it blink!
-
+This tutorial shows you how to create, build and run the Blinky application on a RedBear Nano 2 board.
 <br>
 
 ### Prerequisites
 
-Ensure that you have met the following prerequisites before continuing with this tutorial:
-
+* Meet the prerequisites listed in [Project Blinky](/os/tutorials/blinky.md).
 * Have a RedBear Nano 2 board. 
-* Have Internet connectivity to fetch remote Mynewt components.
-* Have a computer to build a Mynewt application and connect to the board over USB.
-* Install the Newt tool and toolchains (See [Basic Setup](/os/get_started/get_started.md)).
-* Create a project space (directory structure) and populated it with the core code repository (apache-mynewt-core) or know how to as explained in [Creating Your First Project](/os/get_started/project_create).
-* Read the Mynewt OS [Concepts](/os/get_started/vocabulary.md) section.
 
 **Note:** You must install a patched version of OpenOCD .10.0 (See [Debugger Option 2 in the Arduino Primo Blinky Tutorial](/os/tutorials/blinky_primo)).
 
@@ -192,15 +179,3 @@ Loading app image into slot 1
 You should see a blue LED on the board blink!
 
 Note: If the LED does not blink, try resetting your board.
-
-
-### Conclusion
-
-You have created, setup, compiled, loaded, and ran your first mynewt application for a RedBear Nano 2 board.
-
-We have more fun tutorials for you to get your hands dirty. Be bold and work on the OS with tutorials on [writing a test suite](unit_test.md) or try enabling additional functionality such as [remote comms](project-target-slinky.md) or [Bluetooth Low Energy](bletiny_project.md) on your current board.
-
-If you see anything missing or want to send us feedback, please do so by signing up for appropriate mailing lists on our [Community Page](../../community.md).
-
-Keep on hacking and blinking!
-

--- a/docs/os/tutorials/repo/add_repos.md
+++ b/docs/os/tutorials/repo/add_repos.md
@@ -78,7 +78,7 @@ In the same `myproj` above you will see the following repo descriptor.
 ```no-highlight
 repository.apache-Mynewt-core:
     type: github
-    vers: 0-latest
+    vers: 1-latest
     user: apache
     repo: incubator-mynewt-core
 ```
@@ -137,14 +137,14 @@ project.repositories:
 #
 repository.apache-Mynewt-core:
     type: github
-    vers: 0-latest
+    vers: 1-latest
     user: apache
     repo: incubator-mynewt-core
     
 # a special repo to hold hardware specific stuff for arduino zero
 repository.Mynewt_arduino_zero:
     type: github
-    vers: 0-latest
+    vers: 1-latest
     user: runtimeinc
     repo: Mynewt_arduino_zero
 ```
@@ -158,10 +158,10 @@ systems like github.  The repo descriptor in your `project.yml` file must
 specify the version of the repo you will accept into your project.
 
 For now, we are at the beginnings of Mynewt. For testing and evaluation
-please use `0-latest` in the `vers` field in your repo descriptor.
+please use `1-latest` in the `vers` field in your repo descriptor.
 
 ```
-    vers:0-latest
+    vers:1-latest
 ```
 
 See [Create a Repo](create_repo) for a description of the versioning system and all the possible ways to specify a version to use.
@@ -182,15 +182,22 @@ Here is the `repository.yml` file from the apache-Mynewt-core:
 ```no-highlight
 repo.name: apache-mynewt-core
 repo.versions:
-    "0.0.0": "develop"
+    "0.0.0": "master"
+    "0.0.1": "master"
     "0.7.9": "mynewt_0_8_0_b2_tag"
     "0.8.0": "mynewt_0_8_0_tag"
     "0.9.0": "mynewt_0_9_0_tag"
-    "0.9.1": "master"
-    "0-latest": "0.9.0"
-    "0-dev": "0.9.1"
+    "0.9.9": "mynewt_1_0_0_b1_tag"
+    "0.9.99": "mynewt_1_0_0_b2_tag"
+    "0.9.999": "mynewt_1_0_0_rc1_tag"
+    "1.0.0": "mynewt_1_0_0_tag"
+
+    "0-latest": "1.0.0"    # 1.0.0
+    "0-dev": "0.0.0"       # master
+
     "0.8-latest": "0.8.0"
     "0.9-latest": "0.9.0"
+    "1.0-latest": "1.0.0"  # 1.0.0
 ```
 
 <br>
@@ -235,7 +242,7 @@ The stability string can be one of 3 pre-defined stability values.
 In your `project.yml` file you can specify different combinations of 
 the version number and stability value.  For example:
 
-* `0-latest`      -- The latest version with major number 0
+* `1-latest`      -- The latest version with major number 1
 * `1.2-stable`    -- The latest stable version with major and minor number 1.2
 * `1.2-dev`       -- The development version from 1.2
 * `1.1.1`         -- a specific version 1.1.1

--- a/docs/os/tutorials/repo/create_repo.md
+++ b/docs/os/tutorials/repo/create_repo.md
@@ -87,7 +87,7 @@ The stability string can be one of 3 pre-defined stability values.
 In your `project.yml` file you can specify different combinations of 
 the version number and stability value.  For example:
 
-* `0-latest`      -- The latest version with major number 0
+* `1-latest`      -- The latest version with major number 1
 * `1.2-stable`    -- The latest stable version with major and minor number 1.2
 * `1.2-dev`       -- The development version from 1.2
 * `1.1.1`         -- a specific version 1.1.1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,8 @@ pages:
     - Concepts: 'os/get_started/vocabulary.md'
     - Tutorials:
         - toc: 'os/tutorials/tutorials.md'
-        - 'Project Blinky':
+        - 'Project Blinky': 
+            - toc: 'os/tutorials/blinky.md'
             - 'Blinky on Arduino Zero': 'os/tutorials/arduino_zero.md'
             - 'Blinky on Arduino Primo': 'os/tutorials/blinky_primo.md'
             - 'Blinky on Olimex': 'os/tutorials/olimex.md'
@@ -47,10 +48,11 @@ pages:
         - 'Enable Wi-Fi on Arduino MKR1000': 'os/tutorials/wi-fi_on_arduino.md'
         - 'Write a Test Suite for a Package': 'os/tutorials/unit_test.md'
         - 'Events and Event Queues': 'os/tutorials/event_queue.md'
-        - 'Project Slinky for remote comms':
-            - 'Slinky on sim device': 'os/tutorials/project-slinky.md'
-            - 'Slinky on Nordic nRF52 board': 'os/tutorials/project-target-slinky.md'
-            - 'Slinky on STM32 board': 'os/tutorials/project-stm32-slinky.md'
+        - 'Project Slinky for Remote Comms':
+            - toc: 'os/tutorials/project-slinky.md'
+            - 'Slinky on sim device': 'os/tutorials/project-sim-slinky.md'
+            - 'Slinky on Nordic nRF52': 'os/tutorials/project-nrf52-slinky.md'
+            - 'Slinky on Olimex': 'os/tutorials/project-stm32-slinky.md'
         - 'Enable Newt Manager in any app': 'os/tutorials/add_newtmgr.md' 
         - 'Enable the OS Shell and Console': 'os/tutorials/add_shell.md'
         - 'BLE app to check stats via console': 'os/tutorials/bletiny_project.md'


### PR DESCRIPTION
  
1) Updated Check stats on a BLE device tutorial
   -  Removed versions and updated paths.
   - Rename BLE Device to NRF52 Board
   - Added build step for myble target
   - Used new b scan parameters
2) Add load bootloader section to BLE HCI Tutorial
3) Use "main" task instead of "default" task in Add Console and Shell to Blinky tutorial.
4) Remove what the cputime module might be used for
5) Updated Console doc:
   - Added description for minimal package
   - Added newline parameter to console_read function
6) Concepts section - removed "features", added aflags and lflags
7) Use 1-latest instead of 0-latest in Newt Tool Intro
8) Creating first project tutorial: fixed test "libs/os" package to "sys/config" package
   and fixed paths listed in debugger out
9) Changed required GO version to 1.7
10)  Added intro page for blinky tutorials and moved common stuff (description, prerequisites) from individual blinky tutorials to the intro page.
11) Added intro page for slinky tutorials and moved common stuff (description, prerequisites) from
   individual slinky tutorials to the intro page.
12) Renamed project-target-slinky to project-nrf52-slinky and updated link references