### PR TITLE
Added how to install openocd from binary and other minor updates

### DIFF
--- a/docs/newt/install/newt_linux.md
+++ b/docs/newt/install/newt_linux.md
@@ -50,14 +50,14 @@ If you want to build the *newt* tool from its source code, follow the following 
 
     **Note**: The Newt tool requires Go version 1.7 or later.  Currently, the latest Go version that Ubuntu installs is 1.6. You can run `apt-get install golang-1.7-go` to install version 1.7. You can also download version 1.7 from [https://golang.org/dl/](https://golang.org/dl/). 
    
-```no-highlight
+```hl_lines="1 7"
 $sudo apt-get install golang-1.7-go
 Reading package lists... Done
      ...
 Unpacking golang-1.7-go (1.7.1-2ubuntu1) ...
 Setting up golang-1.7-go (1.7.1-2ubuntu1) ...
 $
-$sudo ln -s /usr/lib/go-1.7/bin/go /usr/bin/go
+$sudo ln -sf ../lib/go-1.7/bin/go /usr/bin/go
 $go version
 go version go1.7.1 linux/amd64
 ```

--- a/docs/os/get_started/cross_tools.md
+++ b/docs/os/get_started/cross_tools.md
@@ -1,14 +1,15 @@
 # Installing Cross Tools for ARM 
 
-This page shows how to install tools on your laptop/computer to use for direct communication (e.g. for debugging) with some ARM based HW platforms running Apache Mynewt. You will also have to use the Newt tool installed to run natively on your machine. You may choose to do this instead of using the build toolchain and Newt tool available in a Docker container.
+This page shows how to install tools on your laptop/computer to use for direct communication (e.g. for debugging) with some ARM based HW platforms running Apache Mynewt.  It shows you how to install the following tools for Mac OS X and Linux:
 
-This page provides guidance for installing the tools directly on your MAC and Linux machine. See the relevant sections below.
+* ARM Cross toolchain
+* Debugger to load and debug your device
 
 <br>
 
-## Install ARM Cross tools in Mac OS X
+## Install ARM Cross Toolchain
 
-### Install Tool Chain
+### Install ARM Toolchain For Mac OS X
 
 Install the PX4 Toolchain and check the version installed. ARM maintains a
 pre-built GNU toolchain with a GCC source branch targeted at Embedded ARM
@@ -34,27 +35,7 @@ including the latest releases. However, at present we have tested only with
 this version and recommend it for getting started. 
 
 <br>
-
-### Install OpenOCD
-    
-OpenOCD (Open On-Chip Debugger) is open-source software that allows your
-computer to interface with the JTAG debug connector on a variety of boards.  A
-JTAG connection lets you debug and test embedded target devices. For more on
-OpenOCD go to [http://openocd.org](http://openocd.org).
-
-```no-highlight
-$ brew install open-ocd
-$ which openocd
-/usr/local/bin/openocd
-$ ls -l $(which openocd)
-lrwxr-xr-x  1 <user>  admin  36 Sep 17 16:22 /usr/local/bin/openocd -> ../Cellar/open-ocd/0.9.0/bin/openocd
-```
-
-<br>
-
-## Install ARM cross arm tools for Linux
-
-### Install Tool Chain
+### Install ARM Toolchain For Linux
 
 On a Debian-based Linux distribution, gcc 4.9.3 for ARM can be installed with
 apt-get as documented below. The steps are explained in depth at
@@ -67,21 +48,79 @@ $ sudo apt-get update
 $ sudo apt-get install gcc-arm-none-eabi
 $ sudo apt-get install gdb-arm-none-eabi
 ```
+<br>
+## Install Debugger 
+Mynewt uses, depending on the board, either the OpenOCD or SEGGER J-Link debugger. 
 
 <br>
 
-###Install OpenOCD
 
+### Install OpenOCD
 OpenOCD (Open On-Chip Debugger) is open-source software that allows your
 computer to interface with the JTAG debug connector on a variety of boards.  A
 JTAG connection lets you debug and test embedded target devices. For more on
 OpenOCD go to [http://openocd.org](http://openocd.org).
 
-If you are running Ubuntu 15.x, then you are in luck and you can simply run: 
-```no-highlight
-$ sudo apt-get install openocd 
+OpenOCD version 0.10.0-dev-snapshot that is currently in development is required.  A binary for this version is available to download for Mac OS and Linux
+
+#### Install OpenOCD on Mac OS
+Step 1: Download the [binary tarball for Mac OS](https://github.com/runtimeco/openocd-binaries/raw/master/openocd-bin-89bf96ffe6ac66c80407af8383b9d5adc0dc35f4-MacOS.tgz).
+
+Step 2: Change to the root directory: 
+```no-highlight 
+$cd / 
 ```
- For this project, you should download the openocd 0.8.0 package from
-[https://launchpad.net/ubuntu/vivid/+source/openocd](https://launchpad.net/ubuntu/vivid/+source/openocd).
-The direct link to the amd64 build is
-[http://launchpadlibrarian.net/188260097/openocd_0.8.0-4_amd64.deb](http://launchpadlibrarian.net/188260097/openocd_0.8.0-4_amd64.deb). 
+Step 3: Untar the tarball and install into ** /usr/local/bin**.  You will need to replace ** ~/Downloads ** with the directory that the tarball is downloaded to.  
+```no-highlight
+sudo tar -xf ~/Downloads/openocd-bin-8*-MacOS.tgz ` 
+```
+Step 4: Check the OpenOCD version you are using: 
+
+```no-highlight
+$which openocd
+/usr/local/bin/openocd
+$openocd -v
+Open On-Chip Debugger 0.10.0-dev-snapshot (2017-04-04-14:18)
+Licensed under GNU GPL v2
+For bug reports, read
+http://openocd.org/doc/doxygen/bugs.html
+```
+#### Install OpenOCD on Linux 
+
+Step 1: Download the [binary tarball for Linux 64 bits](https://github.com/runtimeco/openocd-binaries/raw/master/openocd-bin-89bf96ffe6ac66c80407af8383b9d5adc0dc35f4-Linux.tgz). 
+
+Step 2: Change to the root directory: 
+``` 
+$cd / 
+```
+
+Step 3: Untar the tarball and install into ** /usr/local/bin**.  You will need to replace ** ~/Downloads ** with the directory that the tarball is downloaded to.  
+
+```no-highlight
+$sudo tar --no-same-owner -xpf ~/Downloads/openocd-bin-8*-Linux.tgz
+```
+
+Step 4: Check the OpenOCD version you are using: 
+
+```no-highlight
+$which openocd
+/usr/local/bin/openocd
+$openocd -v
+Open On-Chip Debugger 0.10.0-dev-snapshot (2017-04-04-14:18)
+Licensed under GNU GPL v2
+For bug reports, read
+http://openocd.org/doc/doxygen/bugs.html
+```
+You should see version: ** 0.10.0-dev-snapshot (2017-04-04-14:18) **. 
+
+If you see the following error message:
+
+** openocd: error while loading shared libraries: libftdi.so.1: cannot open shared object file: No such file or directory **
+
+run the following to install the library:
+```no-highlight
+$sudo apt-get install libftdi1
+```
+<br>
+###Install SEGGAR J-Link 
+You can download and install Segger J-LINK Software and documentation pack from [SEGGER](https://www.segger.com/jlink-software.html). 

--- a/docs/os/get_started/cross_tools.md
+++ b/docs/os/get_started/cross_tools.md
@@ -52,8 +52,6 @@ $ sudo apt-get install gdb-arm-none-eabi
 ## Install Debugger 
 Mynewt uses, depending on the board, either the OpenOCD or SEGGER J-Link debugger. 
 
-<br>
-
 
 ### Install OpenOCD
 OpenOCD (Open On-Chip Debugger) is open-source software that allows your
@@ -61,65 +59,75 @@ computer to interface with the JTAG debug connector on a variety of boards.  A
 JTAG connection lets you debug and test embedded target devices. For more on
 OpenOCD go to [http://openocd.org](http://openocd.org).
 
-OpenOCD version 0.10.0-dev-snapshot that is currently in development is required.  A binary for this version is available to download for Mac OS and Linux
+OpenOCD version 0.10.0 with nrf52 support is required.  A binary for this version is available to download for Mac OS and Linux.
 
+<br>
 #### Install OpenOCD on Mac OS
-Step 1: Download the [binary tarball for Mac OS](https://github.com/runtimeco/openocd-binaries/raw/master/openocd-bin-89bf96ffe6ac66c80407af8383b9d5adc0dc35f4-MacOS.tgz).
+Step 1: Download the [binary tarball for Mac OS](https://github.com/runtimeco/openocd-binaries/raw/master/openocd-bin-0.10.0-MacOS.tgz).
 
 Step 2: Change to the root directory: 
 ```no-highlight 
 $cd / 
 ```
+<br>
 Step 3: Untar the tarball and install into ** /usr/local/bin**.  You will need to replace ** ~/Downloads ** with the directory that the tarball is downloaded to.  
 ```no-highlight
-sudo tar -xf ~/Downloads/openocd-bin-8*-MacOS.tgz ` 
+sudo tar -xf ~/Downloads/openocd-bin-0.10.0-MacOS.tgz ` 
 ```
+<br>
 Step 4: Check the OpenOCD version you are using: 
 
 ```no-highlight
 $which openocd
 /usr/local/bin/openocd
 $openocd -v
-Open On-Chip Debugger 0.10.0-dev-snapshot (2017-04-04-14:18)
+Open On-Chip Debugger 0.10.0
 Licensed under GNU GPL v2
 For bug reports, read
 http://openocd.org/doc/doxygen/bugs.html
 ```
-#### Install OpenOCD on Linux 
 
-Step 1: Download the [binary tarball for Linux 64 bits](https://github.com/runtimeco/openocd-binaries/raw/master/openocd-bin-89bf96ffe6ac66c80407af8383b9d5adc0dc35f4-Linux.tgz). 
+You should see version: **0.10.0**. 
+
+<br>
+#### Install OpenOCD on Linux 
+Step 1: Download the [binary tarball for Linux](https://github.com/runtimeco/openocd-binaries/raw/master/openocd-bin-0.10.0-Linux.tgz)
 
 Step 2: Change to the root directory: 
 ``` 
 $cd / 
 ```
-
+<br>
 Step 3: Untar the tarball and install into ** /usr/local/bin**.  You will need to replace ** ~/Downloads ** with the directory that the tarball is downloaded to.  
 
-```no-highlight
-$sudo tar --no-same-owner -xpf ~/Downloads/openocd-bin-8*-Linux.tgz
-```
+** Note:** You must specify the -p option for the tar command.
 
+```no-highlight
+$sudo tar -xpf ~/Downloads/openocd-bin-0.10.0-Linux.tgz
+```
+<br>
 Step 4: Check the OpenOCD version you are using: 
 
 ```no-highlight
 $which openocd
 /usr/local/bin/openocd
 $openocd -v
-Open On-Chip Debugger 0.10.0-dev-snapshot (2017-04-04-14:18)
+Open On-Chip Debugger 0.10.0
 Licensed under GNU GPL v2
 For bug reports, read
 http://openocd.org/doc/doxygen/bugs.html
 ```
-You should see version: ** 0.10.0-dev-snapshot (2017-04-04-14:18) **. 
+You should see version: **0.10.0**. 
 
-If you see the following error message:
+If you see any of these error messages:
 
-** openocd: error while loading shared libraries: libftdi.so.1: cannot open shared object file: No such file or directory **
+* openocd: error while loading shared libraries: libhidapi-hidraw.so.0: cannot open shared object file: No such file or directory
 
-run the following to install the library:
+* openocd: error while loading shared libraries: libusb-1.0.so.0: cannot open shared object file: No such file or directory 
+
+run the following command to install the libraries: 
 ```no-highlight
-$sudo apt-get install libftdi1
+$sudo apt-get install libhidapi-dev:i386
 ```
 <br>
 ###Install SEGGAR J-Link 

--- a/docs/os/get_started/get_started.md
+++ b/docs/os/get_started/get_started.md
@@ -3,18 +3,15 @@
 If you are curious about Mynewt and want to get a quick feel for the project, you've come to the right place. We have two options for you:
 
 <br>
+**Option 1 (Recommended)** allows you to install the Newt tool, instances of the Mynewt OS (for simulated targets), and toolchains for developing embedded software (e.g. GNU toolchain) natively on your laptop or computer. We have tried to make the process easy. For example, for the Mac OS we created brew formulas. 
 
-**Option 1** is an easy, self-contained way to get up and running with Mynewt - but has limitations! The Newt tool and build toolchains are all available in a single [All-in-one Docker Container](docker.md) that you can install on your laptop or computer.
-
-However, this is not a long-term option since support is not likely for all features useful or critical to embedded systems development. For example, USB device mapping available in the Docker toolkit (used in this Option 1) is no longer available in the new Docker releases. The Docker option is also typically slower than the native install option. 
-
-<span style="color:red"> Therefore, the recommended option is Option 2 below. </span>
+We recommend this option if you are familiar with such environments or are concerned about performance on your machine. Follow the instructions to [install native tools](native_tools.md) and [install cross tools for ARM](cross_tools.md) if you prefer this option.
 
 <br>
 
-**Option 2 (Recommended)** allows you to install the Newt tool, instances of the Mynewt OS (for simulated targets), and toolchains for developing embedded software (e.g. GNU toolchain) natively on your laptop or computer. We have tried to make the process easy. For example, for the Mac OS we created brew formulas. 
+**Option 2** is an easy, self-contained way to get up and running with Mynewt - but has limitations! The Newt tool and build toolchains are all available in a single [All-in-one Docker Container](docker.md) that you can install on your laptop or computer.
 
-You want this option if you are familiar with such environments or are concerned about performance on your machine. Follow the instructions to [install native tools](native_tools.md) and [install cross tools for ARM](cross_tools.md) if you prefer this option.
+However, this is not a long-term option since support is not likely for all features useful or critical to embedded systems development. For example, USB device mapping available in the Docker toolkit is no longer available in the new Docker releases. The Docker option is also typically slower than the native install option. 
 
 <br>
 

--- a/docs/os/get_started/native_tools.md
+++ b/docs/os/get_started/native_tools.md
@@ -33,8 +33,8 @@ Check the gcc version you have installed (either using brew or previously instal
 
 ```hl_lines="2 3"
 # OS X.
-compiler.path.cc.DARWIN.OVERWRITE: "/usr/local/bin/gcc-5"
-compiler.path.as.DARWIN.OVERWRITE: "/usr/local/bin/gcc-5 -x assembler-with-cpp"
+compiler.path.cc.DARWIN.OVERWRITE: "gcc-5"
+compiler.path.as.DARWIN.OVERWRITE: "gcc-5"
 compiler.path.objdump.DARWIN.OVERWRITE: "gobjdump"
 compiler.path.objsize.DARWIN.OVERWRITE: "objsize"
 compiler.path.objcopy.DARWIN.OVERWRITE: "gobjcopy"
@@ -42,8 +42,8 @@ compiler.path.objcopy.DARWIN.OVERWRITE: "gobjcopy"
 with the following:
 
 ```no-highlight
-compiler.path.cc.DARWIN.OVERWRITE: "/usr/local/bin/gcc-6"
-compiler.path.as.DARWIN.OVERWRITE: "/usr/local/bin/gcc-6 -x assembler-with-cpp”
+compiler.path.cc.DARWIN.OVERWRITE: "gcc-6"
+compiler.path.as.DARWIN.OVERWRITE: "gcc-6”
 ```
 
 <br>
@@ -52,8 +52,8 @@ In case you wish to use Clang, you can change your `<mynewt-src-directory>/repos
 
 ```hl_lines="2 3"
 # OS X.
-compiler.path.cc.DARWIN.OVERWRITE: "/usr/local/bin/gcc-5"
-compiler.path.as.DARWIN.OVERWRITE: "/usr/local/bin/gcc-5 -x assembler-with-cpp"
+compiler.path.cc.DARWIN.OVERWRITE: "gcc-5"
+compiler.path.as.DARWIN.OVERWRITE: "gcc-5"
 compiler.path.objdump.DARWIN.OVERWRITE: "gobjdump"
 compiler.path.objsize.DARWIN.OVERWRITE: "objsize"
 compiler.path.objcopy.DARWIN.OVERWRITE: "gobjcopy"

--- a/docs/os/get_started/project_create.md
+++ b/docs/os/get_started/project_create.md
@@ -89,7 +89,7 @@ repository.apache-mynewt-core:
     user: apache
     repo: incubator-mynewt-core
 ```
-Changing to 1-dev will put you on the develop branch. **The Develop Branch may not be stable and you may encounter bugs or other problems.**
+Changing to 0-dev will put you on the latest master branch. **This branch may not be stable and you may encounter bugs or other problems.**
 
 <br>
 

--- a/docs/os/get_started/vocabulary.md
+++ b/docs/os/get_started/vocabulary.md
@@ -47,8 +47,8 @@ relies upon.
 the ```apache-mynewt-core``` repository.
 
 * ```vers=1-latest```: Defines the repository version. This string will use the 
-latest code in the 'Master' github branch. To use the latest version in the 
-develop branch, just change it to ```vers=1-dev```
+latest stable version in the 'Master' github branch. To use the latest version in the 
+master branch, just change it to ```vers=0-dev```. Note that this branch might not be stable. 
 
 Repositories are versioned collections of packages.  
 

--- a/docs/os/tutorials/arduino_zero.md
+++ b/docs/os/tutorials/arduino_zero.md
@@ -6,6 +6,7 @@ This tutorial shows you how to create, build and run the Blinky application on a
 * Meet the prerequisites listed in [Project Blinky](/os/tutorials/blinky.md).
 * Have an Arduino Zero board.  
 Note: There are many flavors of Arduino. Make sure you are using an Arduino Zero. See below for the versions of Arduino Zero that are compatible with this tutorial.
+* Install the [OpenOCD debugger](/os/get_started/cross_tools/).
 
 This tutorial uses the Arduino Zero Pro board. The tutorial has been tested on the following three Arduino Zero boards - Zero, M0 Pro, and Zero-Pro.
 

--- a/docs/os/tutorials/blinky.md
+++ b/docs/os/tutorials/blinky.md
@@ -23,7 +23,6 @@ Ensure that you meet the following prerequisites before continuing with one of t
 * Have a computer to build a Mynewt application and connect to the board over USB.
 * Have a Micro-USB cable to connect the board and the computer.
 * Install the Newt tool and toolchains (See [Basic Setup](/os/get_started/get_started.md)).
-* Install either the Jlink or OpenOCD debugger.
 * Create a project space (directory structure) and populate it with the core code repository (apache-mynewt-core) or know how to as explained in [Creating Your First Project](/os/get_started/project_create).
 * Read the Mynewt OS [Concepts](/os/get_started/vocabulary.md) section. 
 <br>

--- a/docs/os/tutorials/blinky.md
+++ b/docs/os/tutorials/blinky.md
@@ -23,8 +23,8 @@ Ensure that you meet the following prerequisites before continuing with one of t
 * Have a computer to build a Mynewt application and connect to the board over USB.
 * Have a Micro-USB cable to connect the board and the computer.
 * Install the Newt tool and toolchains (See [Basic Setup](/os/get_started/get_started.md)).
-* Create a project space (directory structure) and populate it with the core code repository (apache-mynewt-core) or know how to as explained in [Creating Your First Project](/os/get_started/project_create).
 * Read the Mynewt OS [Concepts](/os/get_started/vocabulary.md) section. 
+* Create a project space (directory structure) and populate it with the core code repository (apache-mynewt-core) or know how to as explained in [Creating Your First Project](/os/get_started/project_create).
 <br>
 ###Overview of Steps
 These are the general steps to create, load and run the Blinky application on your board:

--- a/docs/os/tutorials/blinky_primo.md
+++ b/docs/os/tutorials/blinky_primo.md
@@ -8,7 +8,7 @@ Note that the Mynewt OS will run on the nRF52 chip in the Arduino Primo board. H
 
 * Meet the the prerequisites listed in [Project Blinky](/os/tutorials/blinky.md).
 * Have an Arduino Primo board.
-* Install a debugger choose one of the two options below:  Option 1 requires additional hardware but very easy to set up. 
+* Install a debugger.  Choose one of the two options below:  Option 1 requires additional hardware but very easy to set up. 
 
 <br>
 ##### Option 1
@@ -17,21 +17,7 @@ Note that the Mynewt OS will run on the nRF52 chip in the Arduino Primo board. H
 * Install the [Segger JLINK Software and documentation pack](https://www.segger.com/jlink-software.html). 
 
 ##### Option 2
-No additional hardware is required but a version of OpenOCD 0.10.0 that is currently in development needs to be installed. A patch for the nRF52 has been applied to the OpenOCD code in development and a tarball has been made available for download [here](downloads/openocd-wnrf52.tgz). Untar it. From the top of the directory tree ("openocd-code-89bf96ffe6ac66c80407af8383b9d5adc0dc35f4"), build it using the following configuration:
-
-```
-$./configure --enable-cmsis-dap --enable-openjtag_ftdi --enable-jlink --enable-stlink
-```
-
-Then run `make` and `sudo make install`. This step takes minutes, so be patient.
-
-```
-$ openocd -v
-Open On-Chip Debugger 0.10.0-dev-snapshot (2016-05-20-10:43)
-Licensed under GNU GPL v2
-For bug reports, read
-    http://openocd.org/doc/doxygen/bugs.html
-```
+This board requires a patch version of OpenOCD 0.10.0 that is in development. See [Install OpenOCD](/os/get_started/cross_tools.md) instructions to install it if you do not have this version installed.
 
 You can now use openocd to upload to Arduino Primo board via the USB port itself.
 

--- a/docs/os/tutorials/nRF52.md
+++ b/docs/os/tutorials/nRF52.md
@@ -12,6 +12,7 @@ Note that there are several versions of the nRF52 in the market. The boards test
 * Have a nRF52 Development Kit (one of the following)
     * Dev Kit from Nordic - PCA 10040
     * Eval Kit from Rigado - BMD-300-EVAL-ES
+* Install the [Segger JLINK Software and documentation pack](https://www.segger.com/jlink-software.html).
 
 This tutorial uses the Nordic nRF52-DK board.
 

--- a/docs/os/tutorials/nrf52_adc.md
+++ b/docs/os/tutorials/nrf52_adc.md
@@ -65,7 +65,7 @@ project.repositories:
 #
 repository.apache-mynewt-core:
     type: github
-    vers: 1-dev
+    vers: 1-latest
     user: apache
     repo: incubator-mynewt-core
 repository.mynewt_nordic:

--- a/docs/os/tutorials/olimex.md
+++ b/docs/os/tutorials/olimex.md
@@ -8,6 +8,8 @@ This tutorial shows you how to create, build, and run the Blinky application on 
 * Have a STM32-E407 development board from Olimex. 
 * Have a ARM-USB-TINY-H connector with JTAG interface for debugging ARM microcontrollers (comes with the ribbon cable to hook up to the board)
 * Have a USB A-B type cable to connect the debugger to your computer.
+* Install the [OpenOCD debugger](/os/get_started/cross_tools/).
+
 <br>
 ### Create a Project
 Create a new project if you do not have an existing one.  You can skip this step and proceed to [create the targets](#create_targets) if you already created a project.

--- a/docs/os/tutorials/project-nrf52-slinky.md
+++ b/docs/os/tutorials/project-nrf52-slinky.md
@@ -4,6 +4,7 @@ This tutorial shows you how to create, build and run the Slinky application and 
 ### Prerequisites
 * Meet the prerequisites listed in [Project Slinky](/os/tutorials/project-slinky.md).  
 * Have a Nordic nRF52-DK board.  
+* Install the [Segger JLINK Software and documentation pack](https://www.segger.com/jlink-software.html).
 
 ### Create a New Project
 Create a new project if you do not have an existing one.  You can skip this step and proceed to [create the targets](#create_targets) if you already have a project created or completed the [Sim Slinky](project-slinky.md) tutorial. 

--- a/docs/os/tutorials/project-stm32-slinky.md
+++ b/docs/os/tutorials/project-stm32-slinky.md
@@ -8,6 +8,7 @@ This tutorial shows you how to create, build and run the Slinky application and 
 * Have a ARM-USB-TINY-H connector with JTAG interface for debugging ARM microcontrollers (comes with the ribbon cable to hook up to the board)
 * Have a USB A-B type cable to connect the debugger to your computer. 
 * Have a USB to TTL Serial Cable with female wiring harness.
+* Install the [OpenOCD debugger](/os/get_started/cross_tools/).
 
 ### Create a New Project
 Create a new project if you do not have an existing one.  You can skip this step and proceed to [create the targets](#create_targets) if you already have a project created or completed the [Sim Slinky](project-slinky.md) tutorial.

--- a/docs/os/tutorials/rbnano2.md
+++ b/docs/os/tutorials/rbnano2.md
@@ -7,8 +7,7 @@ This tutorial shows you how to create, build and run the Blinky application on a
 
 * Meet the prerequisites listed in [Project Blinky](/os/tutorials/blinky.md).
 * Have a RedBear Nano 2 board. 
-
-**Note:** You must install a patched version of OpenOCD .10.0 (See [Debugger Option 2 in the Arduino Primo Blinky Tutorial](/os/tutorials/blinky_primo)).
+* Install a patched version of OpenOCD 0.10.0 described in [Install OpenOCD](os/get_started/cross_tools/).
 
 ### Create a Project  
 Create a new project if you do not have an existing one.  You can skip this step and proceed to [create the targets](#create_targets) if you already have a project created.  

--- a/docs/os/tutorials/tutorials.md
+++ b/docs/os/tutorials/tutorials.md
@@ -11,7 +11,6 @@ The full list of tutorials can be seen in the navigation bar on the left. New on
 * You have installed Docker container of Newt tool and toolchains or you have installed them natively on your machine
 * You have created a new project space (directory structure) and populated it with the core code repository (apache-mynewt-core) or know how to as explained in [Creating Your First Project](../get_started/project_create).
 * You have at least one of the supported development boards:
-    * [STM32F3 discovery kit from ST Micro](STM32F303.md)
     * [Arduino Zero hardware](arduino_zero.md)
     * [Olimex/STM32F407ZGT6 Cortex-M4 hardware](olimex.md)
     * [nRF52 Development Kit from Nordic Semiconductor](nRF52.md)
@@ -28,13 +27,8 @@ The tutorials fall into a few broad categories. Some examples in each category a
 * Making an LED blink (the "Hello World" equivalent in the electronics world)
     * [Blinky on Arduino Zero hardware](arduino_zero.md)
     * [Blinky on Olimex/STM32F407ZGT6 Cortex-M4 hardware](olimex.md)
-    * [Blinky on STM32F3 discovery kit from ST Micro](STM32F303.md)
     * [Blinky on nRF52 Development Kit from Nordic Semiconductor](nRF52.md) **Note:** This supports BLE.
-
-    <br>
-
-* Tweaking available apps to customize behavior e.g. making a more exciting LED blink pattern
-    * [Pinwheel Blinky on STM32F3 discovery board](pin-wheel-mods.md)
+    * [Blinky on Redbear Nano2](rbnano2.md)
 
     <br>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,9 +33,6 @@ pages:
             - 'Blinky on Arduino Zero': 'os/tutorials/arduino_zero.md'
             - 'Blinky on Arduino Primo': 'os/tutorials/blinky_primo.md'
             - 'Blinky on Olimex': 'os/tutorials/olimex.md'
-            - 'Blinky on STM32F303':
-                - toc: 'os/tutorials/STM32F303.md'
-                - 'Pinwheel Blinky': 'os/tutorials/pin-wheel-mods.md'
             - 'Blinky on nRF52': 'os/tutorials/nRF52.md'
             - 'Blinky on RedBear Nano 2': 'os/tutorials/rbnano2.md'
             - 'Add Console and Shell to Blinky': 'os/tutorials/blinky_console.md'


### PR DESCRIPTION
The instructions to install the openocd binary can be reviewed.  Please do not merge yet until Marko has the tarball for the binary that includes the additional support for STM? ( Don't remember the exact number).   