### PR TITLE
Documentation on  how to install newt and newtmgr using brew

### DIFF
--- a/docs/faq/go_env.md
+++ b/docs/faq/go_env.md
@@ -1,0 +1,143 @@
+## Contributing to Newt and Newtmgr Tools
+Newt and Newtmgr are written in Go (golang). This guide shows you how to install Go and setup your environment if
+you would like to contribute to the newt or newtmgr tools.
+
+This guide shows you how to perform the following:
+
+1. Install Go on either Mac OS or Linux.
+2. Setup the Go environment.
+3. Download the newt and newtmgr source code.
+4. Build the newt and newtmgr tools.
+5. Update and rebuild the tools. 
+
+Steps 2-5 apply to both Mac OS and Linux platforms.
+
+**Note:** You will also need to read and follow the instructions from [FAQ](/faq/answers/) to set up your git repos to submit changes.
+
+
+### Step 1: Installing Go 
+The latest master branch of newt and newtmgr requires GO version 1.6 or higher.
+<br>
+#### Installing Go on Mac OS X
+
+If you do not have Homebrew installed, run the following command:
+
+```no-highlight
+$ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+```
+You can also extract (or `git clone`) Homebrew and install it to /usr/local.
+
+<br>
+Use brew to install Go:
+     
+```no-highlight
+$ brew install go
+==> 
+...
+... 
+==> *Summary*
+🍺  //usr/local/Cellar/go/1.8.1: 7,030 files, 281.8MB, built in 1 minute 12 seconds
+```
+You can also download the Go package directly from (https://golang.org/dl/) instead of brewing it. Install it in /usr/local directory.
+
+<br>
+#### Installing Go on Linux
+
+Use apt-get to install Go: 
+```no-highlight
+$sudo apt-get update
+$sudo apt-get install golang 
+Reading package lists... Done
+Building dependency tree       
+Reading state information... Done
+
+      ...
+
+The following NEW packages will be installed:
+  golang
+0 upgraded, 1 newly installed, 0 to remove and 43 not upgraded.
+Need to get 0 B/2,812 B of archives.
+After this operation, 10.2 kB of additional disk space will be used.
+Selecting previously unselected package golang.
+(Reading database ... 244990 files and directories currently installed.)
+Preparing to unpack .../golang_2%3a1.6.1+1ubuntu2_all.deb ...
+Unpacking golang (2:1.6.1+1ubuntu2) ...
+Setting up golang (2:1.6.1+1ubuntu2) ...
+$ go version
+go version go1.6.3 linux/amd64
+```
+<br>
+###Step 2: Setting Up Your Go Environment 
+Go offers you as a developer a language environment (to compile Go code), construct Go packages (to assemble Go packages) and import Go code (from github).  You will use the Go commands to import the **newt** repository into your local Go environment.  Go language environment dictates a specific directory structure, or workspace in Go parlance. It must contain three sibling directories with the names **src**, **pkg** and **bin**: 
+
+* src contains Go source files organized into packages (one package per directory),
+* pkg contains package objects, and
+* bin contains executable commands.
+
+The **GOPATH** environment variable specifies the location of your workspace. To setup this workspace environment, create a **dev** directory and then a **go** directory under it. Set the GOPATH environment variable to this directory where you will clone the newt repository.
+    
+```no-highlight
+$ cd $HOME
+$ mkdir -p dev/go  
+$ cd dev/go
+$ export GOPATH=`pwd`
+```
+<br>
+Add the export GOPATH statement to the ~/.bash_profile file and source the file:
+
+```no-highlight
+$ vi ~/.bash_profile
+$ source ~/.bash_profile
+```
+
+<br>
+
+
+###Step 3: Downloading the Source
+
+Use Go commands to retrieve the latest source from the newt repository (currently the ASF incubator directory). Check that the directories are installed.
+
+```no-highlight
+$ go get mynewt.apache.org/newt/...
+$ ls $GOPATH/src/mynewt.apache.org/newt
+DISCLAIMER	NOTICE		newt		newtvm      viper
+LICENSE		README.md	newtmgr		util        yaml
+```
+
+<br>
+
+### Step 4: Building the Newt and Newtmgr Tools
+Perform the following commands to build the tools:
+```no-highlight
+$ cd $GOPATH/src/mynewt.apache.org/newt/newt
+$ go install
+$ ls $GOPATH/bin/
+newt newtmgr newtvm
+```
+
+<br>
+
+### Step 5: Updating and Rebuilding the Tools
+Change to the directory where you initially installed the tools: 
+
+```no-highlight
+$ cd $GOPATH/src/mynewt.apache.org/newt
+```
+<br>
+Pull the latest source from the repository (you can change to a different branch using git checkout [branch] if you need to)
+```no-highlight
+$ git pull
+```
+<br>
+Install the tools from the latest source:
+```no-highlight
+$ cd newt
+$ go install
+$ cd ../newtmgr
+$ go install
+$ ls $GOPATH /bin/
+newt newtmgr newtvm
+```
+
+This should have updated your newt and newtmgr to the latest version based on the git repository you used.
+

--- a/docs/newt/install/newt_linux.md
+++ b/docs/newt/install/newt_linux.md
@@ -50,14 +50,14 @@ If you want to build the *newt* tool from its source code, follow the following 
 
     **Note**: The Newt tool requires Go version 1.7 or later.  Currently, the latest Go version that Ubuntu installs is 1.6. You can run `apt-get install golang-1.7-go` to install version 1.7. You can also download version 1.7 from [https://golang.org/dl/](https://golang.org/dl/). 
    
-```no-highlight
+```hl_lines="1 7"
 $sudo apt-get install golang-1.7-go
 Reading package lists... Done
      ...
 Unpacking golang-1.7-go (1.7.1-2ubuntu1) ...
 Setting up golang-1.7-go (1.7.1-2ubuntu1) ...
 $
-$sudo ln -s /usr/lib/go-1.7/bin/go /usr/bin/go
+$sudo ln -sf ../lib/go-1.7/bin/go /usr/bin/go
 $go version
 go version go1.7.1 linux/amd64
 ```

--- a/docs/newt/install/newt_mac.md
+++ b/docs/newt/install/newt_mac.md
@@ -1,179 +1,153 @@
-## Install newt tool on your Mac
+## Installing the Newt Tool Mac OS
 
-### Getting your Mac Ready 
+Newt is only supported on Mac OS X 64 bits platforms and has been tested on Mac OS Maverick (10.9) and later.
 
-If you want to build the *newt* tool from its source code, follow the following steps:
+This page shows you how to install the following versions of newt:
 
-<br>
+* The latest stable release version (1.0.0) 
+* The latest from the master branch (unstable)
 
-#### 1. Install Homebrew on your Mac OS X 
+### Installing Homebrew 
 
-* Do you have Homebrew? If not, open a terminal on your Mac and paste the following at a Terminal prompt. It will ask you for your sudo password.
-
-```no-highlight
-        $ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-```
-   Alternatively, you can just extract (or `git clone`) Homebrew and install it to `/usr/local`.
-
-<br>
-
-#### 2. Install Go, the programming language
-
-* Go language environment dictates a directory structure. Known in Go parlanace as workspace, it must contain three sibling directories with the directory names src, pkg and bin, as explained below. 
-
-    * src contains Go source files organized into packages (one package per directory),
-
-    * pkg contains package objects, and
-
-    * bin contains executable commands.
-
-    The GOPATH environment variable specifies the location of your workspace. To setup this workspace environment, create a 'dev' directory and then a 'go' directory under it. Set the GOPATH environment variable to this directory where you will soon clone the *newt* tool repository.
-    
-<br>
+Do you have Homebrew? If not, open a terminal on your Mac and paste the following at a Terminal prompt. It will ask you for your sudo password.
 
 ```no-highlight
-        $ cd $HOME
-        $ mkdir -p dev/go  
-        $ cd dev/go
-        $ export GOPATH=`pwd`
+$ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 ```
-  (Note that you need to add export statements to ~/.bash_profile to export variables permanently. Don't forget to source the file for the change to go into effect.)
+You can also extract (or `git clone`) Homebrew and install it to /usr/local.
 
 <br>
 
+### Installing the Newt Tool
+Add the ** runtimeco/homebrew-mynewt ** tap:
 ```no-highlight
-        $ vi ~/.bash_profile
-        $ source ~/.bash_profile
+$brew tap runtimeco/homebrew-mynewt
+$brew update
 ```
+<br>
+#### Installing the Latest Release Version of Newt
+Install the latest stable release version (1.0.0) of newt:
+```no-highlight
+$brew install mynewt-newt
+==> Installing mynewt-newt from runtimeco/mynewt
+==> Downloading https://github.com/runtimeco/binary-releases/raw/master/mynewt-newt-tools_1.0.0/mynewt-newt-1.0.0.mavericks.bottle.tar.gz
+==> Downloading from https://raw.githubusercontent.com/runtimeco/binary-releases/master/mynewt-newt-tools_1.0.0/mynewt-newt-1.0.0.mavericks.
+######################################################################## 100.0%
+==> Pouring mynewt-newt-1.0.0.mavericks.bottle.tar.gz
+🍺  /usr/local/Cellar/mynewt-newt/1.0.0: 3 files, 10.4MB
+```
+<br>
+**Note:** This installs the newt 1.0.0 binary that has been tested on Mac OS 10.9 and higher. If you are running an earlier version of Mac OS, the installation will install the latest version of Go and compile newt locally.
 
 <br>
-
-* Next, using *brew*, install Go. When installed, Go offers you as a developer a language environment (to compile Go code), construct Go packages (to assemble Go packages) and import Go code (from github). In the next step, you will use the Go commands to import *newt* repo into your local Go environment.
-     
+Check that you are using the installed version of newt:
 ```no-highlight
-        $ brew install go
-        ==> 
-        ...
-        ... 
-        ==> *Summary*
-        🍺  /usr/local/Cellar/go/1.5.1: 5330 files, 273M
+$which newt
+/usr/local/bin/newt
+$ls -l /usr/local/bin/newt
+lrwxr-xr-x  1 user  staff  36 Apr 15 08:18 /usr/local/bin/newt -> ../Cellar/mynewt-newt/1.0.0/bin/newt
+$newt version
+Apache Newt (incubating) version: 1.0.0
 ```
-  Alternatively, you can download the Go package directly from (https://golang.org/dl/) instead of brewing it. Install it in /usr/local directory.
-    
-<br>
-
-#### 3. Create local repository
-
-* Use Go commands to copy the directory (currently the ASF incubator directory). Be patient as it may take a minute or two. Check the directories installed.
-
-```no-highlight
-        $ go get mynewt.apache.org/newt/...
-
-```
-
-* Check that newt.go is in place.
-```no-highlight
-        $ ls $GOPATH/src/mynewt.apache.org/newt
-        DISCLAIMER	NOTICE		newt		newtvm      viper
-        LICENSE		README.md	newtmgr		util        yaml
-```
+**Note:** If you previously built newt from source and the output of `which newt` shows "$GOPATH/bin/newt", you will need to move "$GOPATH/bin"  after "/usr/local/bin" in your $PATH.
 
 <br>
-
-#### 4. Build the Newt tool
-
-* Use Go to run the newt.go program to build the *newt* tool. The command `go install` compiles and writes the resulting executable to an output file named `newt`, which is then installed, along with its dependencies, in $GOPATH/bin.
-
+Run newt help to get information about newt:
 ```no-highlight
-        $ cd $GOPATH/src/mynewt.apache.org/newt/newt
-        $ go install
-        $ ls "$GOPATH"/bin/
-        newt newtmgr newtvm
+$ newt help
+Newt allows you to create your own embedded application based on the Mynewt 
+operating system. Newt provides both build and package management in a single 
+tool, which allows you to compose an embedded application, and set of 
+projects, and then build the necessary artifacts from those projects. For more 
+information on the Mynewt operating system, please visit 
+https://mynewt.apache.org/. 
+
+Please use the newt help command, and specify the name of the command you want 
+help for, for help on how to use a specific command
+
+Usage:
+  newt [flags]
+  newt [command]
+
+Examples:
+  newt
+  newt help [<command-name>]
+    For help on <command-name>.  If not specified, print this message.
+
+Available Commands:
+  build        Build one or more targets
+  clean        Delete build artifacts for one or more targets
+  create-image Add image header to target binary
+  debug        Open debugger session to target
+  info         Show project info
+  install      Install project dependencies
+  load         Load built target to board
+  mfg          Manufacturing flash image commands
+  new          Create a new project
+  pkg          Create and manage packages in the current workspace
+  run          build/create-image/download/debug <target>
+  size         Size of target components
+  sync         Synchronize project dependencies
+  target       Commands to create, delete, configure, and query targets
+  test         Executes unit tests for one or more packages
+  upgrade      Upgrade project dependencies
+  vals         Display valid values for the specified element type(s)
+  version      Display the Newt version number
+
+Flags:
+  -h, --help              Help for newt commands
+  -j, --jobs int          Number of concurrent build jobs (default 8)
+  -l, --loglevel string   Log level (default "WARN")
+  -o, --outfile string    Filename to tee output to
+  -q, --quiet             Be quiet; only display error output
+  -s, --silent            Be silent; don't output anything
+  -v, --verbose           Enable verbose output when executing commands
+
+Use "newt [command] --help" for more information about a command.
 ```
+<br>
+####Updating Newt with Latest Changes from the Master Branch 
+We recommend that you use the latest stable release version (1.0.0) of newt. If you would like to use the master branch with the latest updates, you can install newt from the HEAD of the master branch. 
+
+** Notes: **
+
+* The master branch may be unstable.
+* This installation will install the latest version of Go on your computer, if it is not installed, and compile newt locally. 
+
 
 <br>
-
-* At this point, you can try using *newt*. For example, check for the version number by typing 'newt version'. See all the possible commands available to a user of newt by typing 'newt -h'.
-
-   (Note: If you are going to be modifying the *newt* often and going to be compile the program every time you call it, you will want to store the command in a variable in your .bash_profile. So type in `export newt="go run $GOPATH/mynewt.apache.org/newt/newt/newt.go"` in your .bash_profile and execute it by calling `$newt` at the prompt instead of `newt`. Essentially, `$newt` calls `go run` which runs the compiled binary directly without producing an executable. Don't forget to reload the updated bash profile by typing `source ~/.bash_profile` at the prompt! )
-   
+If you previously installed newt using brew, unlink the current version:
 ```no-highlight
-        $ newt version
-        Newt version:  1.0
-        $ newt -h
-        Newt allows you to create your own embedded application based on the Mynewt 
-        operating system. Newt provides both build and package management in a single 
-        tool, which allows you to compose an embedded application, and set of 
-        projects, and then build the necessary artifacts from those projects. For more 
-        information on the Mynewt operating system, please visit 
-        https://mynewt.apache.org/. 
-
-        Please use the newt help command, and specify the name of the command you want 
-        help for, for help on how to use a specific command
-
-        Usage:
-          newt [flags]
-          newt [command]
-
-        Examples:
-          newt
-          newt help [<command-name>]
-            For help on <command-name>.  If not specified, print this message.
-
-        Available Commands:
-          build        Build one or more targets
-          clean        Delete build artifacts for one or more targets
-          create-image Add image header to target binary
-          debug        Open debugger session to target
-          info         Show project info
-          install      Install project dependencies
-          load         Load built target to board
-          mfg          Manufacturing flash image commands
-          new          Create a new project
-          pkg          Create and manage packages in the current workspace
-          run          build/create-image/download/debug <target>
-          size         Size of target components
-          sync         Synchronize project dependencies
-          target       Commands to create, delete, configure, and query targets
-          test         Executes unit tests for one or more packages
-          upgrade      Upgrade project dependencies
-          vals         Display valid values for the specified element type(s)
-          version      Display the Newt version number
-
-        Flags:
-          -h, --help              Help for newt commands
-          -j, --jobs int          Number of concurrent build jobs (default 8)
-          -l, --loglevel string   Log level (default "WARN")
-          -o, --outfile string    Filename to tee output to
-          -q, --quiet             Be quiet; only display error output
-          -s, --silent            Be silent; don't output anything
-          -v, --verbose           Enable verbose output when executing commands
-
-        Use "newt [command] --help" for more information about a comma
+$brew unlink mynewt-newt
 ```
-
 <br>
-
-#### 5. Updating the Newt tool
-
-* You will update the newt tool in the same place as you initially installed the newt tool.
-* Start by updating the git repository of the newt tool (you can change to a different branch using git checkout [branch] if you need to)
-* Then update each of the tools newt, newtmgr and newtvm as needed
-
+Install the latest unstable version of newt from the master branch:
 ```no-highlight
-        $ cd $GOPATH/src/mynewt.apache.org/newt
-        $ git pull
-        $ cd newt
-        $ go install
-        $ cd ../newtmgr
-        $ go install
-        $ cd ../newtvm
-        $ go install
-        $ ls "$GOPATH"/bin/
-        newt newtmgr newtvm
+$brew install --HEAD mynewt-newt
+==> Installing mynewt-newt from runtimeco/mynewt
+==> Cloning https://github.com/apache/incubator-mynewt-newt.git
+Cloning into 'Users/<username>/Library/Caches/Homebrew/mynewt-newt--git'...
+remote: Counting objects: 623, done.
+remote: Compressing objects: 100% (501/501), done.
+remote: Total 623 (delta 154), reused 323 (delta 84), pack-reused 0
+Receiving objects: 100% (623/623), 1.10 MiB | 0 bytes/s, done.
+Resolving deltas: 100% (154/154), done.
+==> Checking out branch master
+==> go install
+🍺  /usr/local/Cellar/mynewt-newt/HEAD-409f7d3: 3 files, 10.4MB, built in 10 seconds
+$newt version
+Apache Newt (incubating) version: 1.0.0-dev
 ```
-
-That should have updated your newt, newtmgr and newtvm to the latest versions based on the git repository you used.
-
 <br>
-
+####Switching Back to the Stable Release Version
+You can switch back to the stable release version (1.0.0) of newt:
+```no-highlight
+$brew switch mynewt-newt 1.0.0
+Cleaning /usr/local/Cellar/mynewt-newt/1.0.0
+Cleaning /usr/local/Cellar/mynewt-newt/HEAD-409f7d3
+1 links created for /usr/local/Cellar/mynewt-newt/1.0.0
+$newt version
+Apache Newt (incubating) version: 1.0.0
+```
+<br>
+**Note:** If you would like to contribute to the newt tool, see [Setting Up Go Environment to Contribute to Newt and Newtmgr Tools](/faq/go_env).

--- a/docs/newtmgr/install_linux.md
+++ b/docs/newtmgr/install_linux.md
@@ -1,33 +1,25 @@
 
-# Installing Newtmgr
+# Installing Newtmgr on Linux
 
-This page shows you how to install newtmgr from source code.
+This page shows you how to install newtmgr from source code on Linux.
 
 ### Install Go (golang)
 
-If you have not already done so, install Go for your platform.  
+Install Go if it is not installed.  The Newtmgr tool version 1.0.0 requires Go version 1.7 or later.  Currently, the latest Go version that Ubuntu installs is
+1.6. You can run `apt-get install golang-1.7-go` to install version 1.7. You can also download version 1.7 from [https:/
+/golang.org/dl/](https://golang.org/dl/).
 
-The easiest way on a MAC is to use `brew`.  
-
-```no-highlight
-brew install go
-==> Downloading https://homebrew.bintray.com/bottles/go-1.5.3.mavericks.bottle.t
-...
-==> Summary
-🍺  /usr/local/Cellar/go/1.5.3: 5,336 files, 259.6M
+```hl_lines="1 7"
+$sudo apt-get install golang-1.7-go
+Reading package lists... Done
+     ...
+Unpacking golang-1.7-go (1.7.1-2ubuntu1) ...
+Setting up golang-1.7-go (1.7.1-2ubuntu1) ...
+$
+$sudo ln -sf ../lib/go-1.7/bin/go /usr/bin/go
+$go version
+go version go1.7.1 linux/amd64
 ```
-
-<br>
-
-Alternatively, you can download binaries from 
-[the golang.org site](https://golang.org/doc/install)
-To test your Go implementation, you can query Go for its version information
-
-```no-highlight
-$ go version
-go version go1.5.3 darwin/amd64
-```
-
 <br>
 
 To use go, you must set a `$GOPATH` variable in your environment.  This tells
@@ -50,8 +42,7 @@ environment.
 You will first download the source code for newt.
 
 ```no-highlight
-    go get mynewt.apache.org/newt/...
-        (wait a few minutes please, this sits without any indications of working)
+go get mynewt.apache.org/newt/...
 ```
 
 <br>
@@ -62,10 +53,10 @@ Change into the directory where the newmgr tool was downloaded and
 install the newtmgr tool
 
 ```no-highlight
-    cd $GOPATH/src/mynewt.apache.org/newt/newtmgr
-    go install
-    $ ls $GOPATH/bin
-    ... newtmgr	...
+$cd $GOPATH/src/mynewt.apache.org/newt/newtmgr
+$go install
+$ls $GOPATH/bin
+... newtmgr	...
 ```
 
 <br>

--- a/docs/newtmgr/install_mac.md
+++ b/docs/newtmgr/install_mac.md
@@ -1,0 +1,115 @@
+## Installing Newtmgr on Mac OS
+
+Newtmgr is only supported on Mac OS X 64 bits platforms and has been tested on Mac OS Maverick (10.9) and later.
+
+This page shows you how to install the following versions of newtmgr:
+
+* The latest stable release version (1.0.0)
+* The latest from the master branch (unstable)
+
+### Adding the runtimeco/homebrew-mynewt Tap:
+You should have added the runtimeco/homebrew-mynewt tap when you installed the *newt* tool. Run the following commands if you have not done so:
+
+```no-highlight
+$brew tap runtimeco/homebrew-mynewt
+$brew update
+```
+<br>
+### Installing the Latest Release Version of Newtmgr
+Install the latest stable release version (1.0.0) of newtmgr:
+```no-highlight
+brew install mynewt-newtmgr
+==> Installing mynewt-newtmgr from runtimeco/mynewt
+==> Downloading https://github.com/runtimeco/binary-releases/raw/master/mynewt-newt-tools_1.0.0/mynewt-newtmgr-1.0.0.mavericks.bottle.tar.gz
+==> Downloading from https://raw.githubusercontent.com/runtimeco/binary-releases/master/mynewt-newt-tools_1.0.0/mynewt-newtmgr-1.0.0.maveric
+######################################################################## 100.0%
+==> Pouring mynewt-newtmgr-1.0.0.mavericks.bottle.tar.gz
+🍺  /usr/local/Cellar/mynewt-newtmgr/1.0.0: 3 files, 15.2MB
+```
+<br>
+**Note:** This installs the newtmgr 1.0.0 binary that has been tested on Mac OS 10.9 and higher. If you are running an earlier version of Mac OS, the installation will install the latest version of Go and compile newtmgr locally.
+
+<br>
+Check that you are using the installed version of newtmgr:
+```no-highlight
+$which newtmgr
+/usr/local/bin/newtmgr
+ls -l /usr/local/bin/newtmgr
+lrwxr-xr-x  1 user  staff  42 Apr 15 09:14 /usr/local/bin/newtmgr -> ../Cellar/mynewt-newtmgr/1.0.0/bin/newtmgr
+```
+**Note:** If you previously built newtmgr from source and the output of `which newtmgr` shows "$GOPATH/bin/newtmgr", you will need to move "$GOPATH/bin"  after "/usr/local/bin" in your $PATH.
+
+<br>
+Run `newtmgr help` to get information about newtgmr:
+```no-highlight
+$newtmgr help
+Newtmgr helps you manage remote devices running the Mynewt OS
+
+Usage:
+  newtmgr [flags]
+  newtmgr [command]
+
+Available Commands:
+  config      Read or write a config value on a device
+  conn        Manage newtmgr connection profiles
+  crash       Send a crash command to a device
+  datetime    Manage datetime on a device
+  echo        Send data to a device and display the echoed back data
+  fs          Access files on a device
+  image       Manage images on a device
+  log         Manage logs on a device
+  mpstats     Read memory pool statistics from a device
+  reset       Send reset request to a device
+  run         Run test procedures on a device
+  stat        Read statistics from a device
+  taskstats   Read task statistics from a device
+
+Flags:
+  -c, --conn string       connection profile to use
+  -h, --help              Help for newtmgr commands
+  -l, --loglevel string   log level to use (default "info")
+  -t, --trace             print all bytes transmitted and received
+
+Use "newtmgr [command] --help" for more information about a command.
+```
+<br>
+####Updating Newtmgr with Latest Changes from the Master Branch 
+We recommend that you use the latest stable release version (1.0.0) of newtmgr. If you would like to use the master branch with the latest updates, you can install newtmgr from the HEAD of the master branch. 
+
+** Notes: **
+
+* The master branch may be unstable.
+* This installation will install the latest version of Go on your computer, if it is not installed, and compile newtmgr locally. 
+
+<br>
+If you already installed newtgmr, unlink the current version:
+```no-highlight
+$brew unlink mynewt-newtmgr
+```
+<br>
+Install the latest unstable version of newtmgr from the master branch:
+```no-highlight
+brew install --HEAD  mynewt-newtmgr
+==> Installing mynewt-newtmgr from runtimeco/mynewt
+==> Cloning https://github.com/apache/incubator-mynewt-newt.git
+Cloning into '/Users/<user>/Library/Caches/Homebrew/mynewt-newtmgr--git'...
+remote: Counting objects: 623, done.
+remote: Compressing objects: 100% (501/501), done.
+remote: Total 623 (delta 154), reused 323 (delta 84), pack-reused 0
+Receiving objects: 100% (623/623), 1.10 MiB | 0 bytes/s, done.
+Resolving deltas: 100% (154/154), done.
+==> Checking out branch master
+==> go install
+🍺  /usr/local/Cellar/mynewt-newtmgr/HEAD-409f7d3: 3 files, 15.1MB, built in 14 seconds
+```
+<br>
+####Switching Back to the Stable Release Version
+You can switch back to the stable release version (1.0.0) of newtmgr:
+```no-highlight
+brew switch mynewt-newtmgr 1.0.0
+Cleaning /usr/local/Cellar/mynewt-newtmgr/1.0.0
+Cleaning /usr/local/Cellar/mynewt-newtmgr/HEAD-409f7d3
+1 links created for /usr/local/Cellar/mynewt-newtmgr/1.0.0
+```
+<br>
+**Note:** If you would like to contribute to newtmgr tool, see [Setting Up Go Environment to Contribute to Newt and Newtmgr Tools](/faq/go_env).

--- a/docs/os/get_started/cross_tools.md
+++ b/docs/os/get_started/cross_tools.md
@@ -1,14 +1,15 @@
 # Installing Cross Tools for ARM 
 
-This page shows how to install tools on your laptop/computer to use for direct communication (e.g. for debugging) with some ARM based HW platforms running Apache Mynewt. You will also have to use the Newt tool installed to run natively on your machine. You may choose to do this instead of using the build toolchain and Newt tool available in a Docker container.
+This page shows how to install tools on your laptop/computer to use for direct communication (e.g. for debugging) with some ARM based HW platforms running Apache Mynewt.  It shows you how to install the following tools for Mac OS X and Linux:
 
-This page provides guidance for installing the tools directly on your MAC and Linux machine. See the relevant sections below.
+* ARM Cross toolchain
+* Debugger to load and debug your device
 
 <br>
 
-## Install ARM Cross tools in Mac OS X
+## Install ARM Cross Toolchain
 
-### Install Tool Chain
+### Install ARM Toolchain For Mac OS X
 
 Install the PX4 Toolchain and check the version installed. ARM maintains a
 pre-built GNU toolchain with a GCC source branch targeted at Embedded ARM
@@ -34,27 +35,7 @@ including the latest releases. However, at present we have tested only with
 this version and recommend it for getting started. 
 
 <br>
-
-### Install OpenOCD
-    
-OpenOCD (Open On-Chip Debugger) is open-source software that allows your
-computer to interface with the JTAG debug connector on a variety of boards.  A
-JTAG connection lets you debug and test embedded target devices. For more on
-OpenOCD go to [http://openocd.org](http://openocd.org).
-
-```no-highlight
-$ brew install open-ocd
-$ which openocd
-/usr/local/bin/openocd
-$ ls -l $(which openocd)
-lrwxr-xr-x  1 <user>  admin  36 Sep 17 16:22 /usr/local/bin/openocd -> ../Cellar/open-ocd/0.9.0/bin/openocd
-```
-
-<br>
-
-## Install ARM cross arm tools for Linux
-
-### Install Tool Chain
+### Install ARM Toolchain For Linux
 
 On a Debian-based Linux distribution, gcc 4.9.3 for ARM can be installed with
 apt-get as documented below. The steps are explained in depth at
@@ -67,21 +48,79 @@ $ sudo apt-get update
 $ sudo apt-get install gcc-arm-none-eabi
 $ sudo apt-get install gdb-arm-none-eabi
 ```
+<br>
+## Install Debugger 
+Mynewt uses, depending on the board, either the OpenOCD or SEGGER J-Link debugger. 
 
 <br>
 
-###Install OpenOCD
 
+### Install OpenOCD
 OpenOCD (Open On-Chip Debugger) is open-source software that allows your
 computer to interface with the JTAG debug connector on a variety of boards.  A
 JTAG connection lets you debug and test embedded target devices. For more on
 OpenOCD go to [http://openocd.org](http://openocd.org).
 
-If you are running Ubuntu 15.x, then you are in luck and you can simply run: 
-```no-highlight
-$ sudo apt-get install openocd 
+OpenOCD version 0.10.0-dev-snapshot that is currently in development is required.  A binary for this version is available to download for Mac OS and Linux
+
+#### Install OpenOCD on Mac OS
+Step 1: Download the [binary tarball for Mac OS](https://github.com/runtimeco/openocd-binaries/raw/master/openocd-bin-89bf96ffe6ac66c80407af8383b9d5adc0dc35f4-MacOS.tgz).
+
+Step 2: Change to the root directory: 
+```no-highlight 
+$cd / 
 ```
- For this project, you should download the openocd 0.8.0 package from
-[https://launchpad.net/ubuntu/vivid/+source/openocd](https://launchpad.net/ubuntu/vivid/+source/openocd).
-The direct link to the amd64 build is
-[http://launchpadlibrarian.net/188260097/openocd_0.8.0-4_amd64.deb](http://launchpadlibrarian.net/188260097/openocd_0.8.0-4_amd64.deb). 
+Step 3: Untar the tarball and install into ** /usr/local/bin**.  You will need to replace ** ~/Downloads ** with the directory that the tarball is downloaded to.  
+```no-highlight
+sudo tar -xf ~/Downloads/openocd-bin-8*-MacOS.tgz ` 
+```
+Step 4: Check the OpenOCD version you are using: 
+
+```no-highlight
+$which openocd
+/usr/local/bin/openocd
+$openocd -v
+Open On-Chip Debugger 0.10.0-dev-snapshot (2017-04-04-14:18)
+Licensed under GNU GPL v2
+For bug reports, read
+http://openocd.org/doc/doxygen/bugs.html
+```
+#### Install OpenOCD on Linux 
+
+Step 1: Download the [binary tarball for Linux 64 bits](https://github.com/runtimeco/openocd-binaries/raw/master/openocd-bin-89bf96ffe6ac66c80407af8383b9d5adc0dc35f4-Linux.tgz). 
+
+Step 2: Change to the root directory: 
+``` 
+$cd / 
+```
+
+Step 3: Untar the tarball and install into ** /usr/local/bin**.  You will need to replace ** ~/Downloads ** with the directory that the tarball is downloaded to.  
+
+```no-highlight
+$sudo tar --no-same-owner -xpf ~/Downloads/openocd-bin-8*-Linux.tgz
+```
+
+Step 4: Check the OpenOCD version you are using: 
+
+```no-highlight
+$which openocd
+/usr/local/bin/openocd
+$openocd -v
+Open On-Chip Debugger 0.10.0-dev-snapshot (2017-04-04-14:18)
+Licensed under GNU GPL v2
+For bug reports, read
+http://openocd.org/doc/doxygen/bugs.html
+```
+You should see version: ** 0.10.0-dev-snapshot (2017-04-04-14:18) **. 
+
+If you see the following error message:
+
+** openocd: error while loading shared libraries: libftdi.so.1: cannot open shared object file: No such file or directory **
+
+run the following to install the library:
+```no-highlight
+$sudo apt-get install libftdi1
+```
+<br>
+###Install SEGGAR J-Link 
+You can download and install Segger J-LINK Software and documentation pack from [SEGGER](https://www.segger.com/jlink-software.html). 

--- a/docs/os/get_started/native_tools.md
+++ b/docs/os/get_started/native_tools.md
@@ -33,8 +33,8 @@ Check the gcc version you have installed (either using brew or previously instal
 
 ```hl_lines="2 3"
 # OS X.
-compiler.path.cc.DARWIN.OVERWRITE: "/usr/local/bin/gcc-5"
-compiler.path.as.DARWIN.OVERWRITE: "/usr/local/bin/gcc-5 -x assembler-with-cpp"
+compiler.path.cc.DARWIN.OVERWRITE: "gcc-5"
+compiler.path.as.DARWIN.OVERWRITE: "gcc-5"
 compiler.path.objdump.DARWIN.OVERWRITE: "gobjdump"
 compiler.path.objsize.DARWIN.OVERWRITE: "objsize"
 compiler.path.objcopy.DARWIN.OVERWRITE: "gobjcopy"
@@ -42,8 +42,8 @@ compiler.path.objcopy.DARWIN.OVERWRITE: "gobjcopy"
 with the following:
 
 ```no-highlight
-compiler.path.cc.DARWIN.OVERWRITE: "/usr/local/bin/gcc-6"
-compiler.path.as.DARWIN.OVERWRITE: "/usr/local/bin/gcc-6 -x assembler-with-cpp”
+compiler.path.cc.DARWIN.OVERWRITE: "gcc-6"
+compiler.path.as.DARWIN.OVERWRITE: "gcc-6”
 ```
 
 <br>
@@ -52,8 +52,8 @@ In case you wish to use Clang, you can change your `<mynewt-src-directory>/repos
 
 ```hl_lines="2 3"
 # OS X.
-compiler.path.cc.DARWIN.OVERWRITE: "/usr/local/bin/gcc-5"
-compiler.path.as.DARWIN.OVERWRITE: "/usr/local/bin/gcc-5 -x assembler-with-cpp"
+compiler.path.cc.DARWIN.OVERWRITE: "gcc-5"
+compiler.path.as.DARWIN.OVERWRITE: "gcc-5"
 compiler.path.objdump.DARWIN.OVERWRITE: "gobjdump"
 compiler.path.objsize.DARWIN.OVERWRITE: "objsize"
 compiler.path.objcopy.DARWIN.OVERWRITE: "gobjcopy"

--- a/docs/os/get_started/project_create.md
+++ b/docs/os/get_started/project_create.md
@@ -89,7 +89,7 @@ repository.apache-mynewt-core:
     user: apache
     repo: incubator-mynewt-core
 ```
-Changing to 1-dev will put you on the develop branch. **The Develop Branch may not be stable and you may encounter bugs or other problems.**
+Changing to 0-dev will put you on the latest master branch. **This branch may not be stable and you may encounter bugs or other problems.**
 
 <br>
 

--- a/docs/os/get_started/vocabulary.md
+++ b/docs/os/get_started/vocabulary.md
@@ -47,8 +47,8 @@ relies upon.
 the ```apache-mynewt-core``` repository.
 
 * ```vers=1-latest```: Defines the repository version. This string will use the 
-latest code in the 'Master' github branch. To use the latest version in the 
-develop branch, just change it to ```vers=1-dev```
+latest stable version in the 'Master' github branch. To use the latest version in the 
+master branch, just change it to ```vers=0-dev```. Note that this branch might not be stable. 
 
 Repositories are versioned collections of packages.  
 

--- a/docs/os/introduction.md
+++ b/docs/os/introduction.md
@@ -50,7 +50,7 @@ In order to provide all this functionality, and operate in an
 extremely low resource environment, Mynewt provides a very fine-grained source
 package management and build system tool, called *newt*.
 
-You can install and build *newt* for [Linux](../newt/install/newt_linux/) or [Mac](../newt/install/newt_mac/).
+You can install *newt* for [Mac OS](../newt/install/newt_mac/) or [Linux](../newt/install/newt_linux/).
 
 <br>
 
@@ -59,7 +59,7 @@ You can install and build *newt* for [Linux](../newt/install/newt_linux/) or [Ma
 
 In order to enable a user to communicate with remote instances of Mynewt OS and query, configure, and operate them, Mynewt provides an application tool called Newt Manager or `newtmgr`.
 
-You can install and build *newtmgr* from source code on [Linux or Mac](../newtmgr/installing/).
+You can install *newtmgr* for [Mac OS](../newtmgr/install_mac/) or [Linux](../newtmgr/install_linux/).
 
 <br>
 

--- a/docs/os/tutorials/arduino_zero.md
+++ b/docs/os/tutorials/arduino_zero.md
@@ -6,6 +6,7 @@ This tutorial shows you how to create, build and run the Blinky application on a
 * Meet the prerequisites listed in [Project Blinky](/os/tutorials/blinky.md).
 * Have an Arduino Zero board.  
 Note: There are many flavors of Arduino. Make sure you are using an Arduino Zero. See below for the versions of Arduino Zero that are compatible with this tutorial.
+* Install the [OpenOCD debugger](/os/get_started/cross_tools/).
 
 This tutorial uses the Arduino Zero Pro board. The tutorial has been tested on the following three Arduino Zero boards - Zero, M0 Pro, and Zero-Pro.
 

--- a/docs/os/tutorials/blinky.md
+++ b/docs/os/tutorials/blinky.md
@@ -23,7 +23,6 @@ Ensure that you meet the following prerequisites before continuing with one of t
 * Have a computer to build a Mynewt application and connect to the board over USB.
 * Have a Micro-USB cable to connect the board and the computer.
 * Install the Newt tool and toolchains (See [Basic Setup](/os/get_started/get_started.md)).
-* Install either the Jlink or OpenOCD debugger.
 * Create a project space (directory structure) and populate it with the core code repository (apache-mynewt-core) or know how to as explained in [Creating Your First Project](/os/get_started/project_create).
 * Read the Mynewt OS [Concepts](/os/get_started/vocabulary.md) section. 
 <br>

--- a/docs/os/tutorials/blinky.md
+++ b/docs/os/tutorials/blinky.md
@@ -23,8 +23,8 @@ Ensure that you meet the following prerequisites before continuing with one of t
 * Have a computer to build a Mynewt application and connect to the board over USB.
 * Have a Micro-USB cable to connect the board and the computer.
 * Install the Newt tool and toolchains (See [Basic Setup](/os/get_started/get_started.md)).
-* Create a project space (directory structure) and populate it with the core code repository (apache-mynewt-core) or know how to as explained in [Creating Your First Project](/os/get_started/project_create).
 * Read the Mynewt OS [Concepts](/os/get_started/vocabulary.md) section. 
+* Create a project space (directory structure) and populate it with the core code repository (apache-mynewt-core) or know how to as explained in [Creating Your First Project](/os/get_started/project_create).
 <br>
 ###Overview of Steps
 These are the general steps to create, load and run the Blinky application on your board:

--- a/docs/os/tutorials/blinky_primo.md
+++ b/docs/os/tutorials/blinky_primo.md
@@ -8,7 +8,7 @@ Note that the Mynewt OS will run on the nRF52 chip in the Arduino Primo board. H
 
 * Meet the the prerequisites listed in [Project Blinky](/os/tutorials/blinky.md).
 * Have an Arduino Primo board.
-* Install a debugger choose one of the two options below:  Option 1 requires additional hardware but very easy to set up. 
+* Install a debugger.  Choose one of the two options below:  Option 1 requires additional hardware but very easy to set up. 
 
 <br>
 ##### Option 1
@@ -17,21 +17,7 @@ Note that the Mynewt OS will run on the nRF52 chip in the Arduino Primo board. H
 * Install the [Segger JLINK Software and documentation pack](https://www.segger.com/jlink-software.html). 
 
 ##### Option 2
-No additional hardware is required but a version of OpenOCD 0.10.0 that is currently in development needs to be installed. A patch for the nRF52 has been applied to the OpenOCD code in development and a tarball has been made available for download [here](downloads/openocd-wnrf52.tgz). Untar it. From the top of the directory tree ("openocd-code-89bf96ffe6ac66c80407af8383b9d5adc0dc35f4"), build it using the following configuration:
-
-```
-$./configure --enable-cmsis-dap --enable-openjtag_ftdi --enable-jlink --enable-stlink
-```
-
-Then run `make` and `sudo make install`. This step takes minutes, so be patient.
-
-```
-$ openocd -v
-Open On-Chip Debugger 0.10.0-dev-snapshot (2016-05-20-10:43)
-Licensed under GNU GPL v2
-For bug reports, read
-    http://openocd.org/doc/doxygen/bugs.html
-```
+This board requires a patch version of OpenOCD 0.10.0 that is in development. See [Install OpenOCD](/os/get_started/cross_tools.md) instructions to install it if you do not have this version installed.
 
 You can now use openocd to upload to Arduino Primo board via the USB port itself.
 

--- a/docs/os/tutorials/nRF52.md
+++ b/docs/os/tutorials/nRF52.md
@@ -12,6 +12,7 @@ Note that there are several versions of the nRF52 in the market. The boards test
 * Have a nRF52 Development Kit (one of the following)
     * Dev Kit from Nordic - PCA 10040
     * Eval Kit from Rigado - BMD-300-EVAL-ES
+* Install the [Segger JLINK Software and documentation pack](https://www.segger.com/jlink-software.html).
 
 This tutorial uses the Nordic nRF52-DK board.
 

--- a/docs/os/tutorials/nrf52_adc.md
+++ b/docs/os/tutorials/nrf52_adc.md
@@ -65,7 +65,7 @@ project.repositories:
 #
 repository.apache-mynewt-core:
     type: github
-    vers: 1-dev
+    vers: 1-latest
     user: apache
     repo: incubator-mynewt-core
 repository.mynewt_nordic:

--- a/docs/os/tutorials/olimex.md
+++ b/docs/os/tutorials/olimex.md
@@ -8,6 +8,8 @@ This tutorial shows you how to create, build, and run the Blinky application on 
 * Have a STM32-E407 development board from Olimex. 
 * Have a ARM-USB-TINY-H connector with JTAG interface for debugging ARM microcontrollers (comes with the ribbon cable to hook up to the board)
 * Have a USB A-B type cable to connect the debugger to your computer.
+* Install the [OpenOCD debugger](/os/get_started/cross_tools/).
+
 <br>
 ### Create a Project
 Create a new project if you do not have an existing one.  You can skip this step and proceed to [create the targets](#create_targets) if you already created a project.

--- a/docs/os/tutorials/project-nrf52-slinky.md
+++ b/docs/os/tutorials/project-nrf52-slinky.md
@@ -4,6 +4,7 @@ This tutorial shows you how to create, build and run the Slinky application and 
 ### Prerequisites
 * Meet the prerequisites listed in [Project Slinky](/os/tutorials/project-slinky.md).  
 * Have a Nordic nRF52-DK board.  
+* Install the [Segger JLINK Software and documentation pack](https://www.segger.com/jlink-software.html).
 
 ### Create a New Project
 Create a new project if you do not have an existing one.  You can skip this step and proceed to [create the targets](#create_targets) if you already have a project created or completed the [Sim Slinky](project-slinky.md) tutorial. 

--- a/docs/os/tutorials/project-stm32-slinky.md
+++ b/docs/os/tutorials/project-stm32-slinky.md
@@ -8,6 +8,7 @@ This tutorial shows you how to create, build and run the Slinky application and 
 * Have a ARM-USB-TINY-H connector with JTAG interface for debugging ARM microcontrollers (comes with the ribbon cable to hook up to the board)
 * Have a USB A-B type cable to connect the debugger to your computer. 
 * Have a USB to TTL Serial Cable with female wiring harness.
+* Install the [OpenOCD debugger](/os/get_started/cross_tools/).
 
 ### Create a New Project
 Create a new project if you do not have an existing one.  You can skip this step and proceed to [create the targets](#create_targets) if you already have a project created or completed the [Sim Slinky](project-slinky.md) tutorial.

--- a/docs/os/tutorials/rbnano2.md
+++ b/docs/os/tutorials/rbnano2.md
@@ -7,8 +7,7 @@ This tutorial shows you how to create, build and run the Blinky application on a
 
 * Meet the prerequisites listed in [Project Blinky](/os/tutorials/blinky.md).
 * Have a RedBear Nano 2 board. 
-
-**Note:** You must install a patched version of OpenOCD .10.0 (See [Debugger Option 2 in the Arduino Primo Blinky Tutorial](/os/tutorials/blinky_primo)).
+* Install a patched version of OpenOCD 0.10.0 described in [Install OpenOCD](os/get_started/cross_tools/).
 
 ### Create a Project  
 Create a new project if you do not have an existing one.  You can skip this step and proceed to [create the targets](#create_targets) if you already have a project created.  

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,9 +33,6 @@ pages:
             - 'Blinky on Arduino Zero': 'os/tutorials/arduino_zero.md'
             - 'Blinky on Arduino Primo': 'os/tutorials/blinky_primo.md'
             - 'Blinky on Olimex': 'os/tutorials/olimex.md'
-            - 'Blinky on STM32F303':
-                - toc: 'os/tutorials/STM32F303.md'
-                - 'Pinwheel Blinky': 'os/tutorials/pin-wheel-mods.md'
             - 'Blinky on nRF52': 'os/tutorials/nRF52.md'
             - 'Blinky on RedBear Nano 2': 'os/tutorials/rbnano2.md'
             - 'Add Console and Shell to Blinky': 'os/tutorials/blinky_console.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -542,8 +542,11 @@ pages:
             - 'newtmgr run': 'newtmgr/command_list/newtmgr_run.md'
             - 'newtmgr stat': 'newtmgr/command_list/newtmgr_stat.md'
             - 'newtmgr taskstats': 'newtmgr/command_list/newtmgr_taskstats.md'
-        - 'Install': 'newtmgr/installing.md'
+        - 'Install': 
+            - 'Install Newtmgr On Mac OS': 'newtmgr/install_mac.md'
+            - 'Install Newtmgr On Linux':  'newtmgr/install_linux.md'
 - Appendix:
+    - 'Setting Up Go to Contribute to Newt and Newtmgr Tools': 'faq/go_env.md' 
     - 'Edit Docs': 'faq/how_to_edit_docs.md'
     - 'FAQ': 'faq/answers.md'
 


### PR DESCRIPTION
WIP: This contains documentation for installing newt and newtmgr using brew. Will still need to add installation for linux using apt-get (after getting it to work). These changes do contain up-to-date information on how to install using brew and also how to set up Go environment and the source base if they want to contribute to newt or newtmgr.

 Documentation for installing newt and newtmgr using brew
    1) Modified newt_mac.md to use brew
    2) Created a page install_mac.md that documents how to install newtmgr using brew.
    3) Moved and updated newtmgr/installing.md to install newtmgr from source on Linux.
    4) Added a "Setting Up Go Environment to Contribute to Newt and Newtmgr tool" under Appendix.
       Installing newt and newtmgr on Mac refers the user to this page if they want to contribute.
    5) Updated URL references in os/introduction to point to new installation pages.

