### PR TITLE
Documentation for installing newt and newtmgr using brew

### DIFF
--- a/docs/faq/go_env.md
+++ b/docs/faq/go_env.md
@@ -1,0 +1,143 @@
+## Contributing to Newt and Newtmgr Tools
+Newt and Newtmgr are written in Go (golang). This guide shows you how to install Go and setup your environment if
+you would like to contribute to the newt or newtmgr tools.
+
+This guide shows you how to perform the following:
+
+1. Install Go on either Mac OS or Linux.
+2. Setup the Go environment.
+3. Download the newt and newtmgr source code.
+4. Build the newt and newtmgr tools.
+5. Update and rebuild the tools. 
+
+Steps 2-5 apply to both Mac OS and Linux platforms.
+
+**Note:** You will also need to read and follow the instructions from [FAQ](/faq/answers/) to set up your git repos to submit changes.
+
+
+### Step 1: Installing Go 
+The latest master branch of newt and newtmgr requires GO version 1.6 or higher.
+<br>
+#### Installing Go on Mac OS X
+
+If you do not have Homebrew installed, run the following command. You will be prompted for your sudo password.
+
+```no-highlight
+$ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+```
+You can also extract (or `git clone`) Homebrew and install it to /usr/local.
+
+<br>
+Use brew to install Go:
+     
+```no-highlight
+$ brew install go
+==> 
+...
+... 
+==> *Summary*
+🍺  //usr/local/Cellar/go/1.8.1: 7,030 files, 281.8MB, built in 1 minute 12 seconds
+```
+You can also download the Go package directly from (https://golang.org/dl/) instead of brewing it. Install it in /usr/local directory.
+
+<br>
+#### Installing Go on Linux
+
+Use apt-get to install Go: 
+```no-highlight
+$sudo apt-get update
+$sudo apt-get install golang 
+Reading package lists... Done
+Building dependency tree       
+Reading state information... Done
+
+      ...
+
+The following NEW packages will be installed:
+  golang
+0 upgraded, 1 newly installed, 0 to remove and 43 not upgraded.
+Need to get 0 B/2,812 B of archives.
+After this operation, 10.2 kB of additional disk space will be used.
+Selecting previously unselected package golang.
+(Reading database ... 244990 files and directories currently installed.)
+Preparing to unpack .../golang_2%3a1.6.1+1ubuntu2_all.deb ...
+Unpacking golang (2:1.6.1+1ubuntu2) ...
+Setting up golang (2:1.6.1+1ubuntu2) ...
+$ go version
+go version go1.6.3 linux/amd64
+```
+<br>
+###Step 2: Setting Up Your Go Environment 
+Go provides an environment to compile Go code, construct Go packages,  and import Go code.  You will use Go commands to import the **newt** repository into your local Go environment.  The Go language environment dictates a specific directory structure, or workspace in Go parlance. It must contain three sibling directories with the names **src**, **pkg** and **bin**: 
+
+* src contains Go source files organized into packages (one package per directory)
+* pkg contains package objects
+* bin contains executable commands.
+
+The **GOPATH** environment variable specifies the location of your workspace. To setup this workspace environment, create a **dev** directory and then a **go** directory under it. Set the GOPATH environment variable to this directory where you will clone the newt repository.
+    
+```no-highlight
+$ cd $HOME
+$ mkdir -p dev/go  
+$ cd dev/go
+$ export GOPATH=`pwd`
+```
+<br>
+Add the export GOPATH statement to the ~/.bash_profile file and source the file:
+
+```no-highlight
+$ vi ~/.bash_profile
+$ source ~/.bash_profile
+```
+
+<br>
+
+
+###Step 3: Downloading the Source
+
+Use Go commands to retrieve the latest source from the newt repository (currently the ASF incubator directory). Check that the directories are installed.
+
+```no-highlight
+$ go get mynewt.apache.org/newt/...
+$ ls $GOPATH/src/mynewt.apache.org/newt
+DISCLAIMER	NOTICE		newt		newtvm      viper
+LICENSE		README.md	newtmgr		util        yaml
+```
+
+<br>
+
+### Step 4: Building the Newt and Newtmgr Tools
+Perform the following commands to build the tools:
+```no-highlight
+$ cd $GOPATH/src/mynewt.apache.org/newt/newt
+$ go install
+$ ls $GOPATH/bin/
+newt newtmgr newtvm
+```
+
+<br>
+
+### Step 5: Updating and Rebuilding the Tools
+Change to the directory where you initially installed the source: 
+
+```no-highlight
+$ cd $GOPATH/src/mynewt.apache.org/newt
+```
+<br>
+Pull the latest source from the repository (you can change to a different branch using git checkout [branch] if you need to)
+```no-highlight
+$ git pull
+```
+<br>
+Install the tools from the latest source:
+```no-highlight
+$ cd newt
+$ go install
+$ cd ../newtmgr
+$ go install
+$ ls $GOPATH /bin/
+newt newtmgr newtvm
+```
+
+This should have updated your newt and newtmgr to the latest version based on the git repository you used.
+

--- a/docs/newt/install/newt_mac.md
+++ b/docs/newt/install/newt_mac.md
@@ -1,12 +1,13 @@
 ## Installing Newt on Mac OS
 
-Newt is supported on Mac OS X 64 bits platforms and has been tested on Mac OS Maverick (10.9) and later.
+Newt is supported on Mac OS X 64 bit platforms and has been tested on Mac OS 10.9 and higher.
 
 This page shows you how to install the following versions of newt:
 
 * The latest stable release version (1.0.0) 
 * The latest from the master branch (unstable)
 
+**Note:** If you would like to contribute to the newt tool, see [Setting Up Go Environment to Contribute to Newt and Newtmgr Tools](/faq/go_env).
 ### Installing Homebrew 
 
 If you do not have Homebrew installed, run the following command. You will be prompted for your sudo password.
@@ -52,9 +53,9 @@ Apache Newt (incubating) version: 1.0.0
 **Note:** If you previously built newt from source and the output of `which newt` shows "$GOPATH/bin/newt", you will need to move "$GOPATH/bin"  after "/usr/local/bin" in your $PATH.
 
 <br>
-Run `newt help` to get information about newt:
+Get information about newt: 
 ```no-highlight
-$ newt help
+$newt help
 Newt allows you to create your own embedded application based on the Mynewt 
 operating system. Newt provides both build and package management in a single 
 tool, which allows you to compose an embedded application, and set of 
@@ -139,8 +140,7 @@ $newt version
 Apache Newt (incubating) version: 1.0.0-dev
 ```
 <br>
-####Switching Back to the Stable Release Version
-You can switch back to the stable release version (1.0.0) of newt:
+To switch back to the stable release version (1.0.0) of newt, you can run:
 ```no-highlight
 $brew switch mynewt-newt 1.0.0
 Cleaning /usr/local/Cellar/mynewt-newt/1.0.0
@@ -150,4 +150,3 @@ $newt version
 Apache Newt (incubating) version: 1.0.0
 ```
 <br>
-**Note:** If you would like to contribute to the newt tool, see [Setting Up Go Environment to Contribute to Newt and Newtmgr Tools](/faq/go_env).

--- a/docs/newt/install/newt_mac.md
+++ b/docs/newt/install/newt_mac.md
@@ -1,179 +1,153 @@
-## Install newt tool on your Mac
+## Installing Newt on Mac OS
 
-### Getting your Mac Ready 
+Newt is supported on Mac OS X 64 bits platforms and has been tested on Mac OS Maverick (10.9) and later.
 
-If you want to build the *newt* tool from its source code, follow the following steps:
+This page shows you how to install the following versions of newt:
 
-<br>
+* The latest stable release version (1.0.0) 
+* The latest from the master branch (unstable)
 
-#### 1. Install Homebrew on your Mac OS X 
+### Installing Homebrew 
 
-* Do you have Homebrew? If not, open a terminal on your Mac and paste the following at a Terminal prompt. It will ask you for your sudo password.
-
-```no-highlight
-        $ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-```
-   Alternatively, you can just extract (or `git clone`) Homebrew and install it to `/usr/local`.
-
-<br>
-
-#### 2. Install Go, the programming language
-
-* Go language environment dictates a directory structure. Known in Go parlanace as workspace, it must contain three sibling directories with the directory names src, pkg and bin, as explained below. 
-
-    * src contains Go source files organized into packages (one package per directory),
-
-    * pkg contains package objects, and
-
-    * bin contains executable commands.
-
-    The GOPATH environment variable specifies the location of your workspace. To setup this workspace environment, create a 'dev' directory and then a 'go' directory under it. Set the GOPATH environment variable to this directory where you will soon clone the *newt* tool repository.
-    
-<br>
+If you do not have Homebrew installed, run the following command. You will be prompted for your sudo password.
 
 ```no-highlight
-        $ cd $HOME
-        $ mkdir -p dev/go  
-        $ cd dev/go
-        $ export GOPATH=`pwd`
+$ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 ```
-  (Note that you need to add export statements to ~/.bash_profile to export variables permanently. Don't forget to source the file for the change to go into effect.)
+You can also extract (or `git clone`) Homebrew and install it to /usr/local.
 
 <br>
 
+### Installing Newt
+Add the ** runtimeco/homebrew-mynewt ** tap:
 ```no-highlight
-        $ vi ~/.bash_profile
-        $ source ~/.bash_profile
+$brew tap runtimeco/homebrew-mynewt
+$brew update
 ```
+<br>
+#### Installing the Latest Release Version of Newt
+Install the latest stable release version (1.0.0) of newt:
+```no-highlight
+$brew install mynewt-newt
+==> Installing mynewt-newt from runtimeco/mynewt
+==> Downloading https://github.com/runtimeco/binary-releases/raw/master/mynewt-newt-tools_1.0.0/mynewt-newt-1.0.0.mavericks.bottle.tar.gz
+==> Downloading from https://raw.githubusercontent.com/runtimeco/binary-releases/master/mynewt-newt-tools_1.0.0/mynewt-newt-1.0.0.mavericks.
+######################################################################## 100.0%
+==> Pouring mynewt-newt-1.0.0.mavericks.bottle.tar.gz
+🍺  /usr/local/Cellar/mynewt-newt/1.0.0: 3 files, 10.4MB
+```
+<br>
+**Note:** This installs the newt 1.0.0 binary that has been tested on Mac OS 10.9 and higher. If you are running an earlier version of Mac OS, the installation will install the latest version of Go and compile newt locally.
 
 <br>
-
-* Next, using *brew*, install Go. When installed, Go offers you as a developer a language environment (to compile Go code), construct Go packages (to assemble Go packages) and import Go code (from github). In the next step, you will use the Go commands to import *newt* repo into your local Go environment.
-     
+Check that you are using the installed version of newt:
 ```no-highlight
-        $ brew install go
-        ==> 
-        ...
-        ... 
-        ==> *Summary*
-        🍺  /usr/local/Cellar/go/1.5.1: 5330 files, 273M
+$which newt
+/usr/local/bin/newt
+$ls -l /usr/local/bin/newt
+lrwxr-xr-x  1 user  staff  36 Apr 15 08:18 /usr/local/bin/newt -> ../Cellar/mynewt-newt/1.0.0/bin/newt
+$newt version
+Apache Newt (incubating) version: 1.0.0
 ```
-  Alternatively, you can download the Go package directly from (https://golang.org/dl/) instead of brewing it. Install it in /usr/local directory.
-    
-<br>
-
-#### 3. Create local repository
-
-* Use Go commands to copy the directory (currently the ASF incubator directory). Be patient as it may take a minute or two. Check the directories installed.
-
-```no-highlight
-        $ go get mynewt.apache.org/newt/...
-
-```
-
-* Check that newt.go is in place.
-```no-highlight
-        $ ls $GOPATH/src/mynewt.apache.org/newt
-        DISCLAIMER	NOTICE		newt		newtvm      viper
-        LICENSE		README.md	newtmgr		util        yaml
-```
+**Note:** If you previously built newt from source and the output of `which newt` shows "$GOPATH/bin/newt", you will need to move "$GOPATH/bin"  after "/usr/local/bin" in your $PATH.
 
 <br>
-
-#### 4. Build the Newt tool
-
-* Use Go to run the newt.go program to build the *newt* tool. The command `go install` compiles and writes the resulting executable to an output file named `newt`, which is then installed, along with its dependencies, in $GOPATH/bin.
-
+Run `newt help` to get information about newt:
 ```no-highlight
-        $ cd $GOPATH/src/mynewt.apache.org/newt/newt
-        $ go install
-        $ ls "$GOPATH"/bin/
-        newt newtmgr newtvm
+$ newt help
+Newt allows you to create your own embedded application based on the Mynewt 
+operating system. Newt provides both build and package management in a single 
+tool, which allows you to compose an embedded application, and set of 
+projects, and then build the necessary artifacts from those projects. For more 
+information on the Mynewt operating system, please visit 
+https://mynewt.apache.org/. 
+
+Please use the newt help command, and specify the name of the command you want 
+help for, for help on how to use a specific command
+
+Usage:
+  newt [flags]
+  newt [command]
+
+Examples:
+  newt
+  newt help [<command-name>]
+    For help on <command-name>.  If not specified, print this message.
+
+Available Commands:
+  build        Build one or more targets
+  clean        Delete build artifacts for one or more targets
+  create-image Add image header to target binary
+  debug        Open debugger session to target
+  info         Show project info
+  install      Install project dependencies
+  load         Load built target to board
+  mfg          Manufacturing flash image commands
+  new          Create a new project
+  pkg          Create and manage packages in the current workspace
+  run          build/create-image/download/debug <target>
+  size         Size of target components
+  sync         Synchronize project dependencies
+  target       Commands to create, delete, configure, and query targets
+  test         Executes unit tests for one or more packages
+  upgrade      Upgrade project dependencies
+  vals         Display valid values for the specified element type(s)
+  version      Display the Newt version number
+
+Flags:
+  -h, --help              Help for newt commands
+  -j, --jobs int          Number of concurrent build jobs (default 8)
+  -l, --loglevel string   Log level (default "WARN")
+  -o, --outfile string    Filename to tee output to
+  -q, --quiet             Be quiet; only display error output
+  -s, --silent            Be silent; don't output anything
+  -v, --verbose           Enable verbose output when executing commands
+
+Use "newt [command] --help" for more information about a command.
 ```
+<br>
+####Installing Newt from the Master Branch 
+We recommend that you use the latest stable release version (1.0.0) of newt. If you would like to use the master branch with the latest updates, you can install newt from the HEAD of the master branch. 
+
+** Notes: **
+
+* The master branch may be unstable.
+* This installation will install the latest version of Go on your computer, if it is not installed, and compile newt locally. 
+
 
 <br>
-
-* At this point, you can try using *newt*. For example, check for the version number by typing 'newt version'. See all the possible commands available to a user of newt by typing 'newt -h'.
-
-   (Note: If you are going to be modifying the *newt* often and going to be compile the program every time you call it, you will want to store the command in a variable in your .bash_profile. So type in `export newt="go run $GOPATH/mynewt.apache.org/newt/newt/newt.go"` in your .bash_profile and execute it by calling `$newt` at the prompt instead of `newt`. Essentially, `$newt` calls `go run` which runs the compiled binary directly without producing an executable. Don't forget to reload the updated bash profile by typing `source ~/.bash_profile` at the prompt! )
-   
+If you previously installed newt using brew, unlink the current version:
 ```no-highlight
-        $ newt version
-        Newt version:  1.0
-        $ newt -h
-        Newt allows you to create your own embedded application based on the Mynewt 
-        operating system. Newt provides both build and package management in a single 
-        tool, which allows you to compose an embedded application, and set of 
-        projects, and then build the necessary artifacts from those projects. For more 
-        information on the Mynewt operating system, please visit 
-        https://mynewt.apache.org/. 
-
-        Please use the newt help command, and specify the name of the command you want 
-        help for, for help on how to use a specific command
-
-        Usage:
-          newt [flags]
-          newt [command]
-
-        Examples:
-          newt
-          newt help [<command-name>]
-            For help on <command-name>.  If not specified, print this message.
-
-        Available Commands:
-          build        Build one or more targets
-          clean        Delete build artifacts for one or more targets
-          create-image Add image header to target binary
-          debug        Open debugger session to target
-          info         Show project info
-          install      Install project dependencies
-          load         Load built target to board
-          mfg          Manufacturing flash image commands
-          new          Create a new project
-          pkg          Create and manage packages in the current workspace
-          run          build/create-image/download/debug <target>
-          size         Size of target components
-          sync         Synchronize project dependencies
-          target       Commands to create, delete, configure, and query targets
-          test         Executes unit tests for one or more packages
-          upgrade      Upgrade project dependencies
-          vals         Display valid values for the specified element type(s)
-          version      Display the Newt version number
-
-        Flags:
-          -h, --help              Help for newt commands
-          -j, --jobs int          Number of concurrent build jobs (default 8)
-          -l, --loglevel string   Log level (default "WARN")
-          -o, --outfile string    Filename to tee output to
-          -q, --quiet             Be quiet; only display error output
-          -s, --silent            Be silent; don't output anything
-          -v, --verbose           Enable verbose output when executing commands
-
-        Use "newt [command] --help" for more information about a comma
+$brew unlink mynewt-newt
 ```
-
 <br>
-
-#### 5. Updating the Newt tool
-
-* You will update the newt tool in the same place as you initially installed the newt tool.
-* Start by updating the git repository of the newt tool (you can change to a different branch using git checkout [branch] if you need to)
-* Then update each of the tools newt, newtmgr and newtvm as needed
-
+Install the latest unstable version of newt from the master branch:
 ```no-highlight
-        $ cd $GOPATH/src/mynewt.apache.org/newt
-        $ git pull
-        $ cd newt
-        $ go install
-        $ cd ../newtmgr
-        $ go install
-        $ cd ../newtvm
-        $ go install
-        $ ls "$GOPATH"/bin/
-        newt newtmgr newtvm
+$brew install --HEAD mynewt-newt
+==> Installing mynewt-newt from runtimeco/mynewt
+==> Cloning https://github.com/apache/incubator-mynewt-newt.git
+Cloning into 'Users/<username>/Library/Caches/Homebrew/mynewt-newt--git'...
+remote: Counting objects: 623, done.
+remote: Compressing objects: 100% (501/501), done.
+remote: Total 623 (delta 154), reused 323 (delta 84), pack-reused 0
+Receiving objects: 100% (623/623), 1.10 MiB | 0 bytes/s, done.
+Resolving deltas: 100% (154/154), done.
+==> Checking out branch master
+==> go install
+🍺  /usr/local/Cellar/mynewt-newt/HEAD-409f7d3: 3 files, 10.4MB, built in 10 seconds
+$newt version
+Apache Newt (incubating) version: 1.0.0-dev
 ```
-
-That should have updated your newt, newtmgr and newtvm to the latest versions based on the git repository you used.
-
 <br>
-
+####Switching Back to the Stable Release Version
+You can switch back to the stable release version (1.0.0) of newt:
+```no-highlight
+$brew switch mynewt-newt 1.0.0
+Cleaning /usr/local/Cellar/mynewt-newt/1.0.0
+Cleaning /usr/local/Cellar/mynewt-newt/HEAD-409f7d3
+1 links created for /usr/local/Cellar/mynewt-newt/1.0.0
+$newt version
+Apache Newt (incubating) version: 1.0.0
+```
+<br>
+**Note:** If you would like to contribute to the newt tool, see [Setting Up Go Environment to Contribute to Newt and Newtmgr Tools](/faq/go_env).

--- a/docs/newtmgr/install_linux.md
+++ b/docs/newtmgr/install_linux.md
@@ -1,33 +1,25 @@
 
-# Installing Newtmgr
+# Installing Newtmgr on Linux
 
-This page shows you how to install newtmgr from source code.
+This page shows you how to install newtmgr from source code on Linux.
 
 ### Install Go (golang)
 
-If you have not already done so, install Go for your platform.  
+Install Go if it is not installed.  The Newtmgr tool version 1.0.0 requires Go version 1.7 or later.  Currently, the latest Go version that Ubuntu installs is
+1.6. You can run `apt-get install golang-1.7-go` to install version 1.7. You can also download version 1.7 from [https:/
+/golang.org/dl/](https://golang.org/dl/).
 
-The easiest way on a MAC is to use `brew`.  
-
-```no-highlight
-brew install go
-==> Downloading https://homebrew.bintray.com/bottles/go-1.5.3.mavericks.bottle.t
-...
-==> Summary
-🍺  /usr/local/Cellar/go/1.5.3: 5,336 files, 259.6M
+```hl_lines="1 7"
+$sudo apt-get install golang-1.7-go
+Reading package lists... Done
+     ...
+Unpacking golang-1.7-go (1.7.1-2ubuntu1) ...
+Setting up golang-1.7-go (1.7.1-2ubuntu1) ...
+$
+$sudo ln -sf ../lib/go-1.7/bin/go /usr/bin/go
+$go version
+go version go1.7.1 linux/amd64
 ```
-
-<br>
-
-Alternatively, you can download binaries from 
-[the golang.org site](https://golang.org/doc/install)
-To test your Go implementation, you can query Go for its version information
-
-```no-highlight
-$ go version
-go version go1.5.3 darwin/amd64
-```
-
 <br>
 
 To use go, you must set a `$GOPATH` variable in your environment.  This tells
@@ -50,8 +42,7 @@ environment.
 You will first download the source code for newt.
 
 ```no-highlight
-    go get mynewt.apache.org/newt/...
-        (wait a few minutes please, this sits without any indications of working)
+go get mynewt.apache.org/newt/...
 ```
 
 <br>
@@ -62,10 +53,10 @@ Change into the directory where the newmgr tool was downloaded and
 install the newtmgr tool
 
 ```no-highlight
-    cd $GOPATH/src/mynewt.apache.org/newt/newtmgr
-    go install
-    $ ls $GOPATH/bin
-    ... newtmgr	...
+$cd $GOPATH/src/mynewt.apache.org/newt/newtmgr
+$go install
+$ls $GOPATH/bin
+... newtmgr	...
 ```
 
 <br>

--- a/docs/newtmgr/install_mac.md
+++ b/docs/newtmgr/install_mac.md
@@ -1,12 +1,13 @@
 ## Installing Newtmgr on Mac OS
 
-Newtmgr is supported on Mac OS X 64 bits platforms and has been tested on Mac OS Maverick (10.9) and later.
+Newtmgr is supported on Mac OS X 64 bit platforms and has been tested on Mac OS 10.9 and higher.
 
 This page shows you how to install the following versions of newtmgr:
 
 * The latest stable release version (1.0.0)
 * The latest from the master branch (unstable)
 
+**Note:** If you would like to contribute to the newtmgr tool, see [Setting Up Go Environment to Contribute to Newt and Newtmgr Tools](/faq/go_env).
 ### Adding the runtimeco/homebrew-mynewt Tap:
 You should have added the runtimeco/homebrew-mynewt tap when you installed the *newt* tool. Run the following commands if you have not done so:
 
@@ -40,7 +41,7 @@ lrwxr-xr-x  1 user  staff  42 Apr 15 09:14 /usr/local/bin/newtmgr -> ../Cellar/m
 **Note:** If you previously built newtmgr from source and the output of `which newtmgr` shows "$GOPATH/bin/newtmgr", you will need to move "$GOPATH/bin"  after "/usr/local/bin" in your $PATH.
 
 <br>
-Run `newtmgr help` to get information about newtgmr:
+Get information about newtmgr:
 ```no-highlight
 $newtmgr help
 Newtmgr helps you manage remote devices running the Mynewt OS
@@ -89,7 +90,7 @@ $brew unlink mynewt-newtmgr
 <br>
 Install the latest unstable version of newtmgr from the master branch:
 ```no-highlight
-brew install --HEAD  mynewt-newtmgr
+$brew install --HEAD  mynewt-newtmgr
 ==> Installing mynewt-newtmgr from runtimeco/mynewt
 ==> Cloning https://github.com/apache/incubator-mynewt-newt.git
 Cloning into '/Users/<user>/Library/Caches/Homebrew/mynewt-newtmgr--git'...
@@ -103,13 +104,11 @@ Resolving deltas: 100% (154/154), done.
 🍺  /usr/local/Cellar/mynewt-newtmgr/HEAD-409f7d3: 3 files, 15.1MB, built in 14 seconds
 ```
 <br>
-####Switching Back to the Stable Release Version
-You can switch back to the stable release version (1.0.0) of newtmgr:
+To switch back to the stable release version (1.0.0) of newtmgr, you can run:
 ```no-highlight
-brew switch mynewt-newtmgr 1.0.0
+$brew switch mynewt-newtmgr 1.0.0
 Cleaning /usr/local/Cellar/mynewt-newtmgr/1.0.0
 Cleaning /usr/local/Cellar/mynewt-newtmgr/HEAD-409f7d3
 1 links created for /usr/local/Cellar/mynewt-newtmgr/1.0.0
 ```
 <br>
-**Note:** If you would like to contribute to newtmgr tool, see [Setting Up Go Environment to Contribute to Newt and Newtmgr Tools](/faq/go_env).

--- a/docs/newtmgr/install_mac.md
+++ b/docs/newtmgr/install_mac.md
@@ -1,0 +1,115 @@
+## Installing Newtmgr on Mac OS
+
+Newtmgr is supported on Mac OS X 64 bits platforms and has been tested on Mac OS Maverick (10.9) and later.
+
+This page shows you how to install the following versions of newtmgr:
+
+* The latest stable release version (1.0.0)
+* The latest from the master branch (unstable)
+
+### Adding the runtimeco/homebrew-mynewt Tap:
+You should have added the runtimeco/homebrew-mynewt tap when you installed the *newt* tool. Run the following commands if you have not done so:
+
+```no-highlight
+$brew tap runtimeco/homebrew-mynewt
+$brew update
+```
+<br>
+### Installing the Latest Release Version of Newtmgr
+Install the latest stable release version (1.0.0) of newtmgr:
+```no-highlight
+brew install mynewt-newtmgr
+==> Installing mynewt-newtmgr from runtimeco/mynewt
+==> Downloading https://github.com/runtimeco/binary-releases/raw/master/mynewt-newt-tools_1.0.0/mynewt-newtmgr-1.0.0.mavericks.bottle.tar.gz
+==> Downloading from https://raw.githubusercontent.com/runtimeco/binary-releases/master/mynewt-newt-tools_1.0.0/mynewt-newtmgr-1.0.0.maveric
+######################################################################## 100.0%
+==> Pouring mynewt-newtmgr-1.0.0.mavericks.bottle.tar.gz
+🍺  /usr/local/Cellar/mynewt-newtmgr/1.0.0: 3 files, 15.2MB
+```
+<br>
+**Note:** This installs the newtmgr 1.0.0 binary that has been tested on Mac OS 10.9 and higher. If you are running an earlier version of Mac OS, the installation will install the latest version of Go and compile newtmgr locally.
+
+<br>
+Check that you are using the installed version of newtmgr:
+```no-highlight
+$which newtmgr
+/usr/local/bin/newtmgr
+ls -l /usr/local/bin/newtmgr
+lrwxr-xr-x  1 user  staff  42 Apr 15 09:14 /usr/local/bin/newtmgr -> ../Cellar/mynewt-newtmgr/1.0.0/bin/newtmgr
+```
+**Note:** If you previously built newtmgr from source and the output of `which newtmgr` shows "$GOPATH/bin/newtmgr", you will need to move "$GOPATH/bin"  after "/usr/local/bin" in your $PATH.
+
+<br>
+Run `newtmgr help` to get information about newtgmr:
+```no-highlight
+$newtmgr help
+Newtmgr helps you manage remote devices running the Mynewt OS
+
+Usage:
+  newtmgr [flags]
+  newtmgr [command]
+
+Available Commands:
+  config      Read or write a config value on a device
+  conn        Manage newtmgr connection profiles
+  crash       Send a crash command to a device
+  datetime    Manage datetime on a device
+  echo        Send data to a device and display the echoed back data
+  fs          Access files on a device
+  image       Manage images on a device
+  log         Manage logs on a device
+  mpstats     Read memory pool statistics from a device
+  reset       Send reset request to a device
+  run         Run test procedures on a device
+  stat        Read statistics from a device
+  taskstats   Read task statistics from a device
+
+Flags:
+  -c, --conn string       connection profile to use
+  -h, --help              Help for newtmgr commands
+  -l, --loglevel string   log level to use (default "info")
+  -t, --trace             print all bytes transmitted and received
+
+Use "newtmgr [command] --help" for more information about a command.
+```
+<br>
+#### Installing Newtmgr from the Master Branch 
+We recommend that you use the latest stable release version (1.0.0) of newtmgr. If you would like to use the master branch with the latest updates, you can install newtmgr from the HEAD of the master branch. 
+
+** Notes: **
+
+* The master branch may be unstable.
+* This installation will install the latest version of Go on your computer, if it is not installed, and compile newtmgr locally. 
+
+<br>
+If you already installed newtgmr, unlink the current version:
+```no-highlight
+$brew unlink mynewt-newtmgr
+```
+<br>
+Install the latest unstable version of newtmgr from the master branch:
+```no-highlight
+brew install --HEAD  mynewt-newtmgr
+==> Installing mynewt-newtmgr from runtimeco/mynewt
+==> Cloning https://github.com/apache/incubator-mynewt-newt.git
+Cloning into '/Users/<user>/Library/Caches/Homebrew/mynewt-newtmgr--git'...
+remote: Counting objects: 623, done.
+remote: Compressing objects: 100% (501/501), done.
+remote: Total 623 (delta 154), reused 323 (delta 84), pack-reused 0
+Receiving objects: 100% (623/623), 1.10 MiB | 0 bytes/s, done.
+Resolving deltas: 100% (154/154), done.
+==> Checking out branch master
+==> go install
+🍺  /usr/local/Cellar/mynewt-newtmgr/HEAD-409f7d3: 3 files, 15.1MB, built in 14 seconds
+```
+<br>
+####Switching Back to the Stable Release Version
+You can switch back to the stable release version (1.0.0) of newtmgr:
+```no-highlight
+brew switch mynewt-newtmgr 1.0.0
+Cleaning /usr/local/Cellar/mynewt-newtmgr/1.0.0
+Cleaning /usr/local/Cellar/mynewt-newtmgr/HEAD-409f7d3
+1 links created for /usr/local/Cellar/mynewt-newtmgr/1.0.0
+```
+<br>
+**Note:** If you would like to contribute to newtmgr tool, see [Setting Up Go Environment to Contribute to Newt and Newtmgr Tools](/faq/go_env).

--- a/docs/os/introduction.md
+++ b/docs/os/introduction.md
@@ -50,7 +50,7 @@ In order to provide all this functionality, and operate in an
 extremely low resource environment, Mynewt provides a very fine-grained source
 package management and build system tool, called *newt*.
 
-You can install and build *newt* for [Linux](../newt/install/newt_linux/) or [Mac](../newt/install/newt_mac/).
+You can install *newt* for [Mac OS](../newt/install/newt_mac/) or [Linux](../newt/install/newt_linux/).
 
 <br>
 
@@ -59,7 +59,7 @@ You can install and build *newt* for [Linux](../newt/install/newt_linux/) or [Ma
 
 In order to enable a user to communicate with remote instances of Mynewt OS and query, configure, and operate them, Mynewt provides an application tool called Newt Manager or `newtmgr`.
 
-You can install and build *newtmgr* from source code on [Linux or Mac](../newtmgr/installing/).
+You can install *newtmgr* for [Mac OS](../newtmgr/install_mac/) or [Linux](../newtmgr/install_linux/).
 
 <br>
 

--- a/docs/os/tutorials/add_newtmgr.md
+++ b/docs/os/tutorials/add_newtmgr.md
@@ -24,7 +24,7 @@ See [Other Configuration Options](#other-configuration-options) on how to custom
 Ensure that you have met the following prerequisites before continuing with this tutorial:
 
 * Install the [newt tool](../../newt/install/newt_mac.md). 
-* Install the [newtmgr tool](../../newtmgr/installing.md).
+* Install the [newtmgr tool](../../newtmgr/install_mac.md).
 * Have Internet connectivity to fetch remote Mynewt components.
 * Install the [compiler tools](../get_started/native_tools.md) to 
 support native compiling to build the project this tutorial creates.  
@@ -166,7 +166,7 @@ follow the [instructions](../../newtmgr/command_list/newtmgr_conn.md) for settin
 
 <br>
 
-###Connecting with Your Application
+###Communicate with Your Application
 
 Once you have a connection profile set up, you can connect to your device with ```newtmgr -c myconn <command>``` to run commands in your application. 
     

--- a/docs/os/tutorials/project-slinky.md
+++ b/docs/os/tutorials/project-slinky.md
@@ -20,7 +20,7 @@ Ensure that you meet the following prerequisites before continuing with this tut
 * Have a Micro-USB cable to connect the board and the computer.
 * Have a [serial port setup](/os/get_started/serial_access.md).
 * Install the newt tool and the toolchains (See [Basic Setup](/os/get_started/get_started.md)).
-* Install the [newtmgr tool](../../newtmgr/installing/).
+* Install the [newtmgr tool](/newtmgr/install_mac.md).
 * Read the Mynewt OS [Concepts](/os/get_started/vocabulary.md) section.
 * Create a project space (directory structure) and populated it with the core code repository (apache-mynewt-core) or kn
 ow how to as explained in [Creating Your First Project](/os/get_started/project_create).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -545,8 +545,11 @@ pages:
             - 'newtmgr run': 'newtmgr/command_list/newtmgr_run.md'
             - 'newtmgr stat': 'newtmgr/command_list/newtmgr_stat.md'
             - 'newtmgr taskstats': 'newtmgr/command_list/newtmgr_taskstats.md'
-        - 'Install': 'newtmgr/installing.md'
+        - 'Install':
+            - 'Install Newtmgr On Mac OS': 'newtmgr/install_mac.md'
+            - 'Install Newtmgr On Linux':  'newtmgr/install_linux.md'
 - Appendix:
+    - 'Setting Up Go to Contribute to Newt and Newtmgr Tools': 'faq/go_env.md'
     - 'Edit Docs': 'faq/how_to_edit_docs.md'
     - 'FAQ': 'faq/answers.md'
 


### PR DESCRIPTION
1) Modified newt_mac.md to use brew
2) Created newtmgr/install_mac.md that documents how to install newtmgr using brew.
3) Moved and updated newtmgr/installing.md to install_linux.md that documents how to install newtmgr from source on Linux.
4) Added a new "Setting Up Go Environment to Contribute to Newt and Newtmgr tool" page under Appendix.  Installing newt and newtmgr on Mac documents tell the user to reference this page if they want to contribute.
5) Updated URL references in os/introduction to point to new installation pages.