### PR TITLE
Minor edits for installing newt and newtmgr from debian packages

### DIFF
--- a/docs/faq/go_env.md
+++ b/docs/faq/go_env.md
@@ -163,7 +163,7 @@ Check that the newtmgr binary is installed and you are using the one from **$GOP
 ```no-highlight
 $ls $GOPATH/bin/newtmgr
 ~/dev/go/bin/newtmgr
-$which newt
+$which newtmgr
 ~/dev/go/bin/newtmgr
 ```
 <br>

--- a/docs/newt/install/newt_linux.md
+++ b/docs/newt/install/newt_linux.md
@@ -1,12 +1,12 @@
 ## Installing Newt on Linux
 
-You can install the latest stable release (1.0.0) of newt from a Debian binary package (amd64) or from a Debian source package. This page shows you how to:
+You can install the latest stable release (1.0.0) of the newt tool from a Debian binary package (amd64) or from a Debian source package. This page shows you how to:
 
 1. Set up your computer to retrieve Debian packages from the runtimeco debian package repository.
 2. Install the latest stable release version of newt from a Debian binary package. 
 3. Install the latest stable release version of newt from a Debian source package.
 
-If you are running on an amd64 platform, we recommend that you install from the binary package.
+If you are installing on an amd64 platform, we recommend that you install from the binary package.
 
 **Note:** See [Setting Up an Go Environment to Contribute to Newt and Newtmgr Tools](/faq/go_env) if you want to:  
 
@@ -16,18 +16,17 @@ If you are running on an amd64 platform, we recommend that you install from the 
 <br>
 
 ### Setting Up Your Computer to Get Packages from runtimeco 
-The newt Debian packages are stored in a private repository on **https://github/runtimeco/debian-mynewt**. 
+The newt Debian packages are stored in a private repository on **https://github/runtimeco/debian-mynewt**.  The following steps must be performed on your computer to retreive packages from the repository:
 
-**Note:** You will only need to perform these steps only once on your computer.
-The following steps must be performed on your computer:
+**Note:** You only need to perform this setup once on your computer.
 
-1. Add the `apt-transport-https` package to use HTTPS to retrieve packages. 
+1. Install the `apt-transport-https` package to use HTTPS to retrieve packages. 
 2. Download the public key for the runtimeco debian repository and import the key into the apt keychain.
 3. Add the repository for the binary and source packages to the apt source list.
 
 
 <br>
-Add the apt-transport-https package:
+Install the apt-transport-https package:
 ```no-highlight
 $sudo apt-get update
 $sudo apt-get install apt-transport-https
@@ -35,14 +34,14 @@ $sudo apt-get install apt-transport-https
 <br>
 
 
-Download the public key for the runtimeco apt repo (**Note:** There is  `-` after the add):
+Download the public key for the runtimeco apt repo (**Note:** There is  a `-` after  `apt-key add`):
 
 ```no-highlight
 wget -qO - https://raw.githubusercontent.com/runtimeco/debian-mynewt/master/mynewt.gpg.key | sudo apt-key add -
 ```
 <br>
 
-Add the repository for the binary and source packages to the apt source list:
+Add the repository for the binary and source packages to the `mynewt.list` apt source list file.
 
 ```no-highlight
 $sudo -s
@@ -51,26 +50,23 @@ root$ cat > /etc/apt/sources.list.d/mynewt.list <<EOF
 deb https://raw.githubusercontent.com/runtimeco/debian-package/master latest main
 deb-src https://raw.githubusercontent.com/runtimeco/debian-package/master latest main
 EOF
+root$exit
 ```
+**Note:** Do not forget to exit the root shell.
+
 <br>
-Check the content of the file:
+Verify the content of the source list file:
 
 ```no-highlight
-root$more /etc/apt/sources.list.d//mynewt.list
+$more /etc/apt/sources.list.d/mynewt.list
 deb https://raw.githubusercontent.com/runtimeco/debian-package/master latest main
 deb-src https://raw.githubusercontent.com/runtimeco/debian-package/master latest main
 ```
 <br> 
 
-Exit the root shell:
-
-```no-highlight
-root$exit
-```
-<br>
 ### Installing the Latest Release of Newt from a Binary Package 
 
-For Linux amd64 platform, you can install the latest stable version (1.0.0) of newt from the newt Debian binary package:
+For Linux amd64 platforms, you can install the latest stable version (1.0.0) of newt from the newt Debian binary package:
 
 ```no-highlight
 $sudo apt-get update
@@ -93,7 +89,7 @@ See [Checking the Installed Version of Newt](#check) to verify that you are usin
 
 If you are running Linux on a different architecture, you can install the Debian source package for the latest stable release (1.0.0) of newt. The installation of the source package builds the newt binary and creates a Debian binary package that you then install.
 
-**Note**: Newt version 1.0.0 has been tested on Linux amd64 platform. Version 1.0.0 does not build on the 32 bit platform but have been fixed for the next release.
+**Note**: Newt version 1.0.0 has been tested on Linux amd64 platforms. Version 1.0.0 does not build on 32 bit platforms but have been fixed for the next release.
 
 <br>
 #### Installing Go 1.7 
@@ -146,10 +142,12 @@ dpkg-genchanges: info: binary-only upload (no source code included)
 dpkg-buildpackage: info: binary-only upload (no source included)
 W: Can't drop privileges for downloading as file 'newt_1.0.0-1.dsc' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
 ```
-**Note:** You can ignore the "Permission denied: warning message at the end of the command.
+**Note:** You can ignore the "Permission denied" warning message at the end of the command.
 
 <br>
 Install the newt binary package that is created from the source package:
+
+**Note:** The file name for the binary package has the format: newt_1.0.0-1_**arch**.deb,  where **arch** is a value that identifies your host architecture.  
 
 ```no-highlight
 $sudo dpkg -i newt_1.0.0-1_amd64.deb 
@@ -174,7 +172,7 @@ $newt version
 Apache Newt (incubating) version: 1.0.0
 ```
 
-**Note:** If you previously built newt from source and the output of `which newt` shows "$GOPATH/bin/newt", you will need to move "$GOPATH/bin" after "/usr/bin" in your $PATH and export your $PATH.
+**Note:** If you previously built newt from source and the output of `which newt` shows "$GOPATH/bin/newt", you will need to move "$GOPATH/bin" after "/usr/bin" for your PATH environment variable and export it. 
 
 <br>
 Get information about newt:

--- a/docs/newtmgr/install_linux.md
+++ b/docs/newtmgr/install_linux.md
@@ -1,6 +1,6 @@
 ## Installing Newtmgr on Linux
 
-You can install the latest stable release (1.0.0) of newtmgr from a Debian binary package (amd64) or from a Debian source package. This page shows you how to:
+You can install the latest stable release (1.0.0) of the newtmgr tool from a Debian binary package (amd64) or from a Debian source package. This page shows you how to:
 
 1. Set up your computer to retrieve Debian packages from the runtimeco debian package repository. 
 
@@ -9,7 +9,7 @@ You can install the latest stable release (1.0.0) of newtmgr from a Debian binar
 2. Install the latest stable release version of newtmgr from a Debian binary package. 
 3. Install the latest stable release version of newtmgr from a Debian source package.
 
-If you are running on an amd64 platform, we recommend that you install from the binary package.
+If you are installing on an amd64 platform, we recommend that you install from the binary package.
 
 **Note:** See [Setting Up an Go Environment to Contribute to Newt and Newtmgr Tools](/faq/go_env) if you want to:  
 
@@ -20,18 +20,17 @@ If you are running on an amd64 platform, we recommend that you install from the 
 
 ### Setting Up Your Computer to Get Packages from runtimeco 
 
-The newtmgr Debian packages are stored in a private repository on **https://github/runtimeco/debian-mynewt**. 
+The newtmgr Debian packages are stored in a private repository on **https://github/runtimeco/debian-mynewt**.   You must set up the following on your computer to retreive packages from the repository:
 
-**Note**: You will only need to perform these steps once on your computer. You can skip this step if you already set up your computer to access the runtimeco debian repository when you installed the newt tool. 
+**Note**: You only need to perform this setup once on your computer and you may have already done so when you installed the newt tool. 
 
-The following steps must be performed on your computer:
 
-1. Add the `apt-transport-https` package to use HTTPS to retrieve packages. 
+1. Install the `apt-transport-https` package to use HTTPS to retrieve packages. 
 2. Download the public key for the runtimeco debian repository and import the key into the apt keychain.
 3. Add the repository for the binary and source packages to the apt source list.
 
 <br>
-Add the apt-transport-https package:
+Install the apt-transport-https package:
 ```no-highlight
 $sudo apt-get update
 $sudo apt-get install apt-transport-https
@@ -39,14 +38,14 @@ $sudo apt-get install apt-transport-https
 <br>
 
 
-Download the public key for the runtimeco apt repo (**Note:** There is  `-` after the add):
+Download the public key for the runtimeco apt repo  (**Note:** There is  a `-` after  `apt-key add`):
 
 ```no-highlight
 wget -qO - https://raw.githubusercontent.com/runtimeco/debian-mynewt/master/mynewt.gpg.key | sudo apt-key add -
 ```
 <br>
 
-Add the repository for the binary and source packages to the apt source list:
+Add the repository for the binary and source packages to the `mynewt.list` apt source list file.
 
 ```no-highlight
 $sudo -s
@@ -55,26 +54,22 @@ root$ cat > /etc/apt/sources.list.d/mynewt.list <<EOF
 deb https://raw.githubusercontent.com/runtimeco/debian-package/master latest main
 deb-src https://raw.githubusercontent.com/runtimeco/debian-package/master latest main
 EOF
+root$exit
 ```
+**Note:** Do not forget to exit the root shell.
+
 <br>
-Check the content of the file:
+Verify the content of the source list file:
 
 ```no-highlight
-root$more /etc/apt/sources.list.d//mynewt.list
+$more /etc/apt/sources.list.d/mynewt.list
 deb https://raw.githubusercontent.com/runtimeco/debian-package/master latest main
 deb-src https://raw.githubusercontent.com/runtimeco/debian-package/master latest main
 ```
 <br> 
-
-Exit the root shell:
-
-```no-highlight
-root$exit
-```
-<br>
 ### Installing the Latest Release of Newtmgr from a Binary Package 
 
-For Linux amd64 platform, you can install the latest stable version (1.0.0) of newtmgr from the newtmgr Debian binary package:
+For Linux amd64 platforms, you can install the latest stable version (1.0.0) of newtmgr from the newtmgr Debian binary package:
 
 ```no-highlight
 $sudo apt-get update
@@ -101,7 +96,7 @@ See [Checking the Installed Version of Newtmgr](#check) to verify that you are u
 
 If you are running Linux on a different architecture, you can install the Debian source package for the latest stable release (1.0.0) of newtmgr. The installation of the source package builds the newtmgr binary and creates a Debian binary package that you then install.
 
-**Note**: Newtmgr version 1.0.0 has been tested on Linux amd64 platform. 
+**Note**: Newtmgr version 1.0.0 has been tested on Linux amd64 platforms. 
 
 <br>
 #### Installing Go 1.7 
@@ -150,14 +145,23 @@ dpkg-deb: building package 'newtmgr' in '../newtmgr_1.0.0-1_amd64.deb'.
 dpkg-genchanges: info: binary-only upload (no source code included)
  dpkg-source --after-build newtmgr-1.0.0
 dpkg-buildpackage: info: binary-only upload (no source included)
+W: Can't drop privileges for downloading as file 'newtmgr_1.0.0-1.dsc' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
 ```
+**Note:** You can ignore the "Permission denied" warning message at the end of the command.
+
 
 <br>
 Install the newtmgr binary package that is created from the source package:
 
+**Note:** The file name for the binary package has the format: newtmgr_1.0.0-1_**arch**.deb,  where **arch** is a value that identifies your host architecture.
+
 ```no-highlight
 $sudo dpkg -i newtmgr_1.0.0-1_amd64.deb 
-
+Selecting previously unselected package newtmgr.
+(Reading database ... 215099 files and directories currently installed.)
+Preparing to unpack newtmgr_1.0.0-1_amd64.deb ...
+Unpacking newtmgr (1.0.0-1) ...
+Setting up newtmgr (1.0.0-1) ...
 ```
 <br>
 ###<a name="check"></a> Checking the Installed Version of Newtmgr
@@ -172,7 +176,8 @@ $which newtmgr
 /usr/bin/newtmgr
 ```
 
-**Note:** If you previously built newtmgr from source and the output of `which newtmgr` shows "$GOPATH/bin/newtmgr", you will need to move "$GOPATH/bin" after "/usr/bin" in your $PATH and export your $PATH.
+**Note:** If you previously built newtmgr from source and the output of `which newtmgr` shows "$GOPATH/bin/newtmgr", you will need to move "$GOPATH/bin" after "/usr/bin" for your PATH environment variable and export it.
+
 
 <br>
 Get information about newtmgr:

--- a/docs/os/get_started/native_install_intro.md
+++ b/docs/os/get_started/native_install_intro.md
@@ -1,0 +1,17 @@
+# Native Installation 
+
+This section shows you how to install tools on Mac OS and Linux platforms to develop, build, run, and debug Mynewt OS applications. You can build Mynewt OS applications to run as a native application on your computer or to run on your target board. These tools include:
+
+* Newt tool - Tool to create, build, load, and debug a mynewt target.
+
+    * See [Installing the Newt Tool on Mac OS](/newt/install/newt_mac.md) to install on Mac OS.
+    * See [Installing the Newt Tool on Linux](/newt/install/newt_linux.md) to install on Linux.
+
+
+<br>
+
+* Native toolchain - Native toolchain to build and run Mynewt OS as a native application on your computer.
+  (See [Installing Native Toolchain](/os/get_started/native_install.md)).  
+
+* Cross toolchain for ARM - Cross toolchain for ARM to build and run a Mynewt OS application on a target board
+  (See [Installing Cross Tools for ARMs](/os/get_started/cross_tools.md)).

--- a/docs/os/get_started/native_tools.md
+++ b/docs/os/get_started/native_tools.md
@@ -139,4 +139,4 @@ Setting up gdb (7.7.1-0ubuntu5~14.04.2) ...
 
 <br>
 
-At this point you have installed all the necessary software to build and test code on a simluator running on your Mac or Linux. Proceed to the [Create Your First Project](project_create.md) section.
+At this point you have installed all the necessary software to build and run your first project on a simluator on your Mac OS or Linux computer. You may proceed to the [Create Your First Project](project_create.md) section or continue to the next section and install the cross tools for ARM.

--- a/docs/os/get_started/project_create.md
+++ b/docs/os/get_started/project_create.md
@@ -4,14 +4,13 @@ This page shows how to create a Mynewt Project using the `newt` command-line too
 
 <br>
 
-### Pre-Requisites
+### Prerequisites
 
-* Newt:
+* Have Internet connectivity to fetch remote Mynewt components.
+* Install Newt:
+    * If you have taken the native install route,  see the installation instructions for [Mac OS](../../newt/install/newt_mac.md) or for [Linux](../../newt/install/newt_linux.md). 
     * If you have taken the Docker route, you have already installed Newt.
-    * If you have taken the native install route, you have to ensure that you have installed the Newt tool following the instructions for [Mac](../../newt/install/newt_mac.md) or [Linux](../../newt/install/newt_linux.md) as appropriate, and that the `newt` command is in your system path. 
-* You must have Internet connectivity to fetch remote Mynewt components.
-* You must [install the compiler tools](native_tools.md) to 
-support native compiling to build the project this tutorial creates.  
+* Install the [native toolchain](native_tools.md) to compile and build a Mynewt native application. 
 
 <br>
 
@@ -32,7 +31,7 @@ Project myproj successfully created.
 Newt populates this new project with a base skeleton of a new Apache Mynewt 
 project.  It has the following structure. 
 
-**Note**: If you do not have `tree`, install it by running `brew install tree`.
+**Note**: If you do not have `tree`, run `brew install tree` to install on Mac OS or run `sudo apt-get install tree` to install on Linux.
 
 ```no-highlight 
 $ cd myproj

--- a/docs/os/tutorials/add_newtmgr.md
+++ b/docs/os/tutorials/add_newtmgr.md
@@ -23,12 +23,10 @@ See [Other Configuration Options](#other-configuration-options) on how to custom
 ### Prerequisites
 Ensure that you have met the following prerequisites before continuing with this tutorial:
 
-* Install the [newt tool](../../newt/install/newt_mac.md). 
-* Install the [newtmgr tool](../../newtmgr/install_mac.md).
 * Have Internet connectivity to fetch remote Mynewt components.
-* Install the [compiler tools](../get_started/native_tools.md) to 
-support native compiling to build the project this tutorial creates.  
 * Have a cable to establish a serial USB connection between the board and the laptop.
+* Install the newt tool and toolchains (See [Basic Setup](/os/get_started/get_started.md)).
+* Install the [newtmgr tool](../../newtmgr/install_mac.md).
 
 <br>
 

--- a/docs/os/tutorials/add_shell.md
+++ b/docs/os/tutorials/add_shell.md
@@ -7,16 +7,13 @@ can interact with your project over a serial line connection.
 
 <br>
 
-### Pre-Requisites
+### Prerequisites
+Ensure that you have met the following prerequisites before continuing with this tutorial:
 
-* Ensure you have installed [newt](../../newt/install/newt_mac.md) and that the 
-newt command is in your system path. 
-* You must have Internet connectivity to fetch remote Mynewt components.
-* You must [install the compiler tools](../get_started/native_tools.md) to 
-support native compiling to build the project this tutorial creates.  
-* You must install the [Segger JLINK package]( https://www.segger.com/jlink-software.html) to 
-load your project on the board.
-* Cable to establish a serial USB connection between the board and the laptop
+* Have Internet connectivity to fetch remote Mynewt components.  
+* Have a cable to establish a serial USB connection between the board and the laptop
+* Install the newt tool and toolchains (See [Basic Setup](/os/get_started/get_started.md)).
+* Install the [Segger JLINK package]( https://www.segger.com/jlink-software.html) to load your project on the board.
 
 <br>
 

--- a/docs/os/tutorials/arduino_zero.md
+++ b/docs/os/tutorials/arduino_zero.md
@@ -41,7 +41,7 @@ Run the following commands to create a new project:
 ###<a name="fetchexternal"></a> Fetch External Packages
 
 Mynewt uses source code provided directly from the chip manufacturer for
-low level operations. Sometimes this code is licensed only for the specific manufacturer of the chipset and cannot live in the Apache Mynewt repository. That happens to be the case for the Arduino Zero board which uses Atmel SAMD21. Runtime's github repository hosts such external third-party packages and the Newt tool can fetch them.
+low level operations. Sometimes this code is licensed only for the specific manufacturer of the chipset and cannot live in the Apache Mynewt repository. That happens to be the case for the Arduino Zero board which uses Atmel SAMD21. Runtime's github repository hosts such external third-party packages and the newt tool can fetch them.
 
 To fetch the package with MCU support for Atmel SAMD21 for Arduino Zero from the Runtime git repository, you need to add
 the repository to the `project.yml` file in your base project directory.

--- a/docs/os/tutorials/blehci_project.md
+++ b/docs/os/tutorials/blehci_project.md
@@ -8,22 +8,20 @@ The host used in this specific example is the BlueZ Bluetooth stack. Since BlueZ
 
 <br>
 
-### Pre-Requisites
+### Prerequisites
+Ensure that you meet the following prerequisites before continuing with one of the tutorials.
 
-* Ensure you have installed [newt](../../newt/install/newt_mac.md) and that the 
-newt command is in your system path. 
-* You must have Internet connectivity to fetch remote Mynewt components.
-* If you are not using the Docker container for newt and other tools, you must [install the compiler tools](../get_started/native_tools.md) to 
-support native compiling to build the project this tutorial creates.  
-* You have a board with BLE radio that is supported by Mynewt. We will use an nRF52 Dev board in this tutorial.
-* USB TTL Serial Cable that supports hardware flow control such as ones found at [http://www.ftdichip.com/Products/Cables/USBTTLSerial.htm](http://www.ftdichip.com/Products/Cables/USBTTLSerial.htm) to establish a serial USB connection between the board and the laptop.
-* You have installed a BLE host such as BlueZ on a Linux machine to talk to the nrf52 board running Mynewt. Use `sudo apt-get install bluez` to install it on your Linux machine. 
+* Have Internet connectivity to fetch remote Mynewt components.
+* Have a board with BLE radio that is supported by Mynewt. We will use an nRF52 Dev board in this tutorial.
+* Have a USB TTL Serial Cable that supports hardware flow control such as ones found at [http://www.ftdichip.com/Products/Cables/USBTTLSerial.htm](http://www.ftdichip.com/Products/Cables/USBTTLSerial.htm) to establish a serial USB connection between the board and the laptop.
+* Install the newt tool and toolchains (See [Basic Setup](/os/get_started/get_started.md)).
+* Install a BLE host such as BlueZ on a Linux machine to talk to the nrf52 board running Mynewt. Use `sudo apt-get install bluez` to install it on your Linux machine. 
 
 <br>
 
 ### Create a project
 
-Use the Newt tool to create a new project directory containing a skeletal Mynewt framework. Change into the newly created directory. 
+Use the newt tool to create a new project directory containing a skeletal Mynewt framework. Change into the newly created directory. 
 
 ```
 $ newt new blehciproj 

--- a/docs/os/tutorials/bletiny_project.md
+++ b/docs/os/tutorials/bletiny_project.md
@@ -8,20 +8,19 @@ This tutorial explains how to run an example BLE app on a board and command it t
 
 ### Prerequisites
 
-* Ensure you have installed [newt](../../newt/install/newt_mac.md) and that the 
-newt command is in your system path. 
-* You must have Internet connectivity to fetch remote Mynewt components.
-* You must [install the compiler tools](../get_started/native_tools.md) to 
-support native compiling to build the project this tutorial creates.  
-* You must install the [Segger JLINK package]( https://www.segger.com/jlink-software.html) to load your project on the board.
-* You have a board with BLE radio that is supported by Mynewt. We will use an nRF52 Dev board in this tutorial.
-* Cable to establish a serial USB connection between the board and the laptop
+Ensure that you have met the following prerequisites before continuing with this tutorial:
+
+* Have Internet connectivity to fetch remote Mynewt components.
+* Have a board with BLE radio that is supported by Mynewt. We will use an nRF52 Dev board in this tutorial.
+* Have a cable to establish a serial USB connection between the board and the laptop
+* Install the newt tool and toolchains (See [Basic Setup](/os/get_started/get_started.md)).
+* Install the [Segger JLINK package]( https://www.segger.com/jlink-software.html) to load your project on the board.
 
 <br>
 
 ### Create a project
 
-Use the Newt tool to create a new project directory containing a skeletal Mynewt framework. Change into the newly created directory.
+Use the newt tool to create a new project directory containing a skeletal Mynewt framework. Change into the newly created directory.
 
 ```no-highlight
 $ newt new myproj 

--- a/docs/os/tutorials/blinky.md
+++ b/docs/os/tutorials/blinky.md
@@ -22,7 +22,7 @@ Ensure that you meet the following prerequisites before continuing with one of t
 * Have Internet connectivity to fetch remote Mynewt components.
 * Have a computer to build a Mynewt application and connect to the board over USB.
 * Have a Micro-USB cable to connect the board and the computer.
-* Install the Newt tool and toolchains (See [Basic Setup](/os/get_started/get_started.md)).
+* Install the newt tool and toolchains (See [Basic Setup](/os/get_started/get_started.md)).
 * Read the Mynewt OS [Concepts](/os/get_started/vocabulary.md) section. 
 * Create a project space (directory structure) and populate it with the core code repository (apache-mynewt-core) or know how to as explained in [Creating Your First Project](/os/get_started/project_create).
 <br>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,10 +17,11 @@ pages:
     - toc: 'os/introduction.md'
     - Basic Setup:
         - toc: 'os/get_started/get_started.md'
-        - 'Native install Option':
-            - toc: 'os/get_started/native_tools.md'
+        - Native Install Option:
+            - toc: 'os/get_started/native_install_intro.md'
             - 'Install Newt on Mac': 'newt/install/newt_mac.md'
             - 'Install Newt on Linux': 'newt/install/newt_linux.md'
+            - 'Install Native Toolchain': 'os/get_started/native_tools.md'
             - 'Install Cross Tools for ARM': 'os/get_started/cross_tools.md'
         - 'Docker Container Option': 'os/get_started/docker.md'
         - 'Create Your First Project': 'os/get_started/project_create.md'
@@ -28,7 +29,7 @@ pages:
     - Concepts: 'os/get_started/vocabulary.md'
     - Tutorials:
         - toc: 'os/tutorials/tutorials.md'
-        - Project Blinky: 
+        - Project Blinky:
             - toc: 'os/tutorials/blinky.md'
             - 'Blinky on Arduino Zero': 'os/tutorials/arduino_zero.md'
             - 'Blinky on Arduino Primo': 'os/tutorials/blinky_primo.md'


### PR DESCRIPTION
We can leave this PR open  so I can make any other updates as needed after others  have tested the installation.

Fixed ordering of installation sequence of newt tool and native tool chain. 