### PR TITLE
Fixed broken links.

### DIFF
--- a/docs/os/get_started/native_install_intro.md
+++ b/docs/os/get_started/native_install_intro.md
@@ -11,7 +11,7 @@ This section shows you how to install tools on Mac OS and Linux platforms to dev
 <br>
 
 * Native toolchain - Native toolchain to build and run Mynewt OS as a native application on your computer.
-  (See [Installing Native Toolchain](/os/get_started/native_install.md)).  
+  (See [Installing Native Toolchain](/os/get_started/native_tools.md)).  
 
 * Cross toolchain for ARM - Cross toolchain for ARM to build and run a Mynewt OS application on a target board
   (See [Installing Cross Tools for ARMs](/os/get_started/cross_tools.md)).

--- a/docs/os/tutorials/blinky_stm32f4disc.md
+++ b/docs/os/tutorials/blinky_stm32f4disc.md
@@ -9,7 +9,7 @@ This tutorial shows you how to create, build, and run the Blinky application on 
 * Meet the prerequisites listed in [Project Blinky](/os/tutorials/blinky.md).
 * Have a STM32F4-Discovery board.
 * Have a USB type A to Mini-B cable.    
-* Install a patched version of OpenOCD 0.10.0 described in [Install OpenOCD](os/get_started/cross_tools/).  
+* Install a patched version of OpenOCD 0.10.0 described in [Install OpenOCD](/os/get_started/cross_tools/).  
 
 ### Create a Project  
 Create a new project if you do not have an existing one.  You can skip this step and proceed to [create the targets](#create_targets) if you already have a project created.  

--- a/docs/os/tutorials/rbnano2.md
+++ b/docs/os/tutorials/rbnano2.md
@@ -7,7 +7,7 @@ This tutorial shows you how to create, build and run the Blinky application on a
 
 * Meet the prerequisites listed in [Project Blinky](/os/tutorials/blinky.md).
 * Have a RedBear Nano 2 board. 
-* Install a patched version of OpenOCD 0.10.0 described in [Install OpenOCD](os/get_started/cross_tools/).
+* Install a patched version of OpenOCD 0.10.0 described in [Install OpenOCD](/os/get_started/cross_tools/).
 
 ### Create a Project  
 Create a new project if you do not have an existing one.  You can skip this step and proceed to [create the targets](#create_targets) if you already have a project created.  


### PR DESCRIPTION
1) Fixed broken link to install openocd debugger in redbear nano2 and stm32f4disc blinky tutorials
2) Fixed broken link to installing native toolchain in the the native installation introduction page.