### PR TITLE
Fixed incorrect repo urls in mynewt.list source list.

### DIFF
--- a/docs/newt/install/newt_linux.md
+++ b/docs/newt/install/newt_linux.md
@@ -47,8 +47,8 @@ Add the repository for the binary and source packages to the `mynewt.list` apt s
 $sudo -s
 [sudo] password for <user>:
 root$ cat > /etc/apt/sources.list.d/mynewt.list <<EOF
-deb https://raw.githubusercontent.com/runtimeco/debian-package/master latest main
-deb-src https://raw.githubusercontent.com/runtimeco/debian-package/master latest main
+deb https://raw.githubusercontent.com/runtimeco/debian-mynewt/master latest main
+deb-src https://raw.githubusercontent.com/runtimeco/debian-mynewt/master latest main
 EOF
 root$exit
 ```
@@ -59,8 +59,8 @@ Verify the content of the source list file:
 
 ```no-highlight
 $more /etc/apt/sources.list.d/mynewt.list
-deb https://raw.githubusercontent.com/runtimeco/debian-package/master latest main
-deb-src https://raw.githubusercontent.com/runtimeco/debian-package/master latest main
+deb https://raw.githubusercontent.com/runtimeco/debian-mynewt/master latest main
+deb-src https://raw.githubusercontent.com/runtimeco/debian-mynewt/master latest main
 ```
 <br> 
 

--- a/docs/newtmgr/install_linux.md
+++ b/docs/newtmgr/install_linux.md
@@ -51,8 +51,8 @@ Add the repository for the binary and source packages to the `mynewt.list` apt s
 $sudo -s
 [sudo] password for <user>:
 root$ cat > /etc/apt/sources.list.d/mynewt.list <<EOF
-deb https://raw.githubusercontent.com/runtimeco/debian-package/master latest main
-deb-src https://raw.githubusercontent.com/runtimeco/debian-package/master latest main
+deb https://raw.githubusercontent.com/runtimeco/debian-mynewt/master latest main
+deb-src https://raw.githubusercontent.com/runtimeco/debian-mynewt/master latest main
 EOF
 root$exit
 ```
@@ -63,8 +63,8 @@ Verify the content of the source list file:
 
 ```no-highlight
 $more /etc/apt/sources.list.d/mynewt.list
-deb https://raw.githubusercontent.com/runtimeco/debian-package/master latest main
-deb-src https://raw.githubusercontent.com/runtimeco/debian-package/master latest main
+deb https://raw.githubusercontent.com/runtimeco/debian-mynewt/master latest main
+deb-src https://raw.githubusercontent.com/runtimeco/debian-mynewt/master latest main
 ```
 <br> 
 ### Installing the Latest Release of Newtmgr from a Binary Package 


### PR DESCRIPTION
Should be debian-mynewt instead of debian-package