### PR TITLE
Note install for newt and newtmgr may not work on Ubuntu version < 16

### DIFF
--- a/docs/newt/install/newt_linux.md
+++ b/docs/newt/install/newt_linux.md
@@ -8,15 +8,18 @@ You can install the latest stable release (1.0.0) of the newt tool from a Debian
 
 If you are installing on an amd64 platform, we recommend that you install from the binary package.
 
+**Note:**  We have tested the newt tool binary and apt-get install from the runtimeco Debian package repository for Ubuntu version 16.  Earlier Ubuntu versions (for example: Ubuntu 14) may have incompatibility with the repository. We recommend that you upgrade Ubuntu on your computer. 
+
+
 **Note:** See [Setting Up an Go Environment to Contribute to Newt and Newtmgr Tools](/faq/go_env) if you want to:  
 
 * Use the newt tool with the latest updates from the master branch. The master branch may be unstable and we recommend that you use the latest stable release version.
 * Contribute to the newt tool. 
 
 <br>
-
 ### Setting Up Your Computer to Get Packages from runtimeco 
 The newt Debian packages are stored in a private repository on **https://github/runtimeco/debian-mynewt**.  The following steps must be performed on your computer to retreive packages from the repository:
+
 
 **Note:** You only need to perform this setup once on your computer.
 
@@ -62,14 +65,38 @@ $more /etc/apt/sources.list.d/mynewt.list
 deb https://raw.githubusercontent.com/runtimeco/debian-mynewt/master latest main
 deb-src https://raw.githubusercontent.com/runtimeco/debian-mynewt/master latest main
 ```
+<br>
+Update the available packages: 
+```no-highlight
+$sudo apt-get update
+```
+<br>
+**Note:** If you are not using Ubuntu version 16, you may see the following errors.  We recommend that you upgrade Ubuntu.  We have provided instructions on how to manually download and install the binary package if you choose not to upgrade, but you will want to upgrade Ubuntu if you are installing from source.
+
+
+```no-highlight
+
+W: Failed to fetch https://raw.githubusercontent.com/runtimeco/debian-mynewt/master/dists/latest/main/source/Sources  HttpError404
+
+W: Failed to fetch https://raw.githubusercontent.com/runtimeco/debian-mynewt/master/dists/latest/main/binary-amd64/Packages  Bad header line
+
+W: Failed to fetch https://raw.githubusercontent.com/runtimeco/debian-mynewt/master/dists/latest/main/binary-i386/Packages  HttpError404
+
+E: Some index files failed to download. They have been ignored, or old ones used instead.
+
+```
+
+<br>
+
+
 <br> 
 
 ### Installing the Latest Release of Newt from a Binary Package 
 
-For Linux amd64 platforms, you can install the latest stable version (1.0.0) of newt from the newt Debian binary package:
+For Linux amd64 platforms, you can install the latest stable version (1.0.0) of newt from the newt Debian binary package. 
+
 
 ```no-highlight
-$sudo apt-get update
 $sudo apt-get install newt
 Reading package lists... Done
 Building dependency tree       
@@ -80,6 +107,14 @@ Reading state information... Done
 Preparing to unpack .../newt_1.0.0-1_amd64.deb ...
 Unpacking newt (1.0.0-1) ...
 Setting up newt (1.0.0-1) ...
+```
+<br>
+
+**Note:**If you are not using Ubuntu version 16 and are not able to update the runtimeco Debian package repo on your computer successfully, you can manually download and install the newt_1.0.0-1_amd64.deb binary package as follows:
+
+```no-highlight
+$wget https://raw.githubusercontent.com/runtimeco/debian-mynewt/master/pool/main/n/newt/newt_1.0.0-1_amd64.deb
+$sudo dpkg -i newt_1.0.0-1_amd64.deb
 ```
 <br>
 See [Checking the Installed Version of Newt](#check) to verify that you are using the installed version of newt.

--- a/docs/newtmgr/install_linux.md
+++ b/docs/newtmgr/install_linux.md
@@ -1,6 +1,6 @@
 ## Installing Newtmgr on Linux
 
-You can install the latest stable release (1.0.0) of the newtmgr tool from a Debian binary package (amd64) or from a Debian source package. This page shows you how to:
+You can install the latest stable release (1.0.0) of the newtmgr tool from a Debian binary package (amd64) or from a Debian source package.  This page shows you how to:
 
 1. Set up your computer to retrieve Debian packages from the runtimeco debian package repository. 
 
@@ -10,6 +10,9 @@ You can install the latest stable release (1.0.0) of the newtmgr tool from a Deb
 3. Install the latest stable release version of newtmgr from a Debian source package.
 
 If you are installing on an amd64 platform, we recommend that you install from the binary package.
+
+**Note:**  We have tested the newtmgr tool binary and apt-get install from the runtimeco Debian package repository for Ubuntu version 16.  Earlier Ubuntu versions (for example: Ubuntu 14) may have incompatibility with the repository. We recommend that you upgrade Ubuntu on your computer.
+
 
 **Note:** See [Setting Up an Go Environment to Contribute to Newt and Newtmgr Tools](/faq/go_env) if you want to:  
 
@@ -66,13 +69,34 @@ $more /etc/apt/sources.list.d/mynewt.list
 deb https://raw.githubusercontent.com/runtimeco/debian-mynewt/master latest main
 deb-src https://raw.githubusercontent.com/runtimeco/debian-mynewt/master latest main
 ```
+<br>
+Update the available packages:
+```no-highlight
+$sudo apt-get update
+```
+<br>
+**Note:** If you are not using Ubuntu version 16, you may see the following errors.  We recommend that you upgrade Ubuntu.  We have provided instructions on how to manually download and install the binary package if you choose not to upgrade, but you will want to upgrade Ubuntu if you are installing from source.  
+
+```no-highlight
+
+W: Failed to fetch https://raw.githubusercontent.com/runtimeco/debian-mynewt/master/dists/latest/main/source/Sources  Ht
+tpError404
+
+W: Failed to fetch https://raw.githubusercontent.com/runtimeco/debian-mynewt/master/dists/latest/main/binary-amd64/Packa
+ges  Bad header line
+
+W: Failed to fetch https://raw.githubusercontent.com/runtimeco/debian-mynewt/master/dists/latest/main/binary-i386/Packag
+es  HttpError404
+
+E: Some index files failed to download. They have been ignored, or old ones used instead.
+
+```
 <br> 
 ### Installing the Latest Release of Newtmgr from a Binary Package 
 
 For Linux amd64 platforms, you can install the latest stable version (1.0.0) of newtmgr from the newtmgr Debian binary package:
 
 ```no-highlight
-$sudo apt-get update
 $sudo apt-get install newtmgr
 Reading package lists... Done
 Building dependency tree       
@@ -88,6 +112,14 @@ Preparing to unpack .../newtmgr_1.0.0-1_amd64.deb ...
 Unpacking newtmgr (1.0.0-1) ...
 Setting up newtmgr (1.0.0-1) 
 ```
+<br>
+**Note:** If you are not using Ubuntu version 16 and are not able to update the runtimeco Debian package repo on your computer successfully, you can manually download and install the newtmgr_1.0.0-1_amd64.deb binary package as follows:
+
+```no-highlight
+$wget https://raw.githubusercontent.com/runtimeco/debian-mynewt/master/pool/main/n/newtmgr/newtmgr_1.0.0-1_amd64.deb
+$sudo dpkg -i newtmgr_1.0.0-1_amd64.deb
+```
+
 <br>
 See [Checking the Installed Version of Newtmgr](#check) to verify that you are using the installed version of newtmgr.
 


### PR DESCRIPTION

1) Add note that we tested newt and newtmgr tool binaries and installation on Ubuntu version 16 and may
not work on earlier versions.
2) Provided instructions on how to manually download and install binary if user doesn't want to upgrade Ubuntu. But recommend they will want to upgrade if installing from source.