### PR TITLE
Tell Windows users to change vers to 0-dev to use master branch.

### DIFF
--- a/docs/os/get_started/project_create.md
+++ b/docs/os/get_started/project_create.md
@@ -103,6 +103,8 @@ repository.apache-mynewt-core:
 
 Changing vers to 0-dev will put you on the latest master branch. **This branch may not be stable and you may encounter bugs or other problems.**
 
+**Note:** On Windows platforms,  you will need to change vers to 0-dev and use the latest master branch. Release 1.0.0 is not supported on Windows.
+
 <br>
 Run the `newt install` command, from your project base directory (myproj), to fetch the source repository and dependencies: 
 


### PR DESCRIPTION

newt 1.0.0-dev version pulls down project.yml with vers: 1-latest. This pulls down apache-mynewt-core mynewt_1_0_0_tag. Windows users need to use the master branch.
