### PR TITLE
Update installation instructions for Windows

### DIFF
--- a/docs/newt/install/newt_windows.md
+++ b/docs/newt/install/newt_windows.md
@@ -95,11 +95,10 @@ README.md		newtvm
 Check that the newt tool is installed and it is in your path:
 
 ```no-highlight
-$ls go/bin
-$ ls bin/newt
-bin/newt
-$which go
-/home/<user>/dev/go/bin/newt
+$ls $GOPATH/bin/newt
+~/dev/go/bin/newt
+$which newt
+~/dev/go/bin/newt
 $ newt version
 Apache Newt (incubating) version: 1.0.0-dev
 ```

--- a/docs/newtmgr/install_windows.md
+++ b/docs/newtmgr/install_windows.md
@@ -26,7 +26,7 @@ Check that the newtmgr binary is installed and you are using the one from **$GOP
 ```no-highlight
 $ls $GOPATH/bin/newtmgr
 ~/dev/go/bin/newtmgr
-$which newt
+$which newtmgr
 ~/dev/go/bin/newtmgr
 ```
 <br>

--- a/docs/os/get_started/project_create.md
+++ b/docs/os/get_started/project_create.md
@@ -311,7 +311,7 @@ All tests passed
 ### Building and Running the Simulated Blinky Application
 The section shows you how to build and run the blinky application to run on Mynewt's simulated hardware.
 
-**Note**: This is not yet supported on Windows. Refer to the [Blinky Tutorials](/os/tutorials/blinky.md) to create a blinky application on a target boards.
+**Note**: This is not yet supported on Windows. Refer to the [Blinky Tutorials](/os/tutorials/blinky.md) to create a blinky application for a target board.
 
 <br>
 ####Building the Application

--- a/docs/os/tutorials/arduino_zero.md
+++ b/docs/os/tutorials/arduino_zero.md
@@ -50,6 +50,8 @@ Here is an example ```project.yml``` file with the Arduino Zero repository
 added. The sections with ```mynewt_arduino_zero``` that need to be added to
 your project file are highlighted.
 
+**Note:** On Windows platforms: You need to set `vers` to `0-dev` and use the latest master branch for both repositories.
+
 ```hl_lines="6 14 15 16 17 18"
 $ more project.yml
 project.name: "my_project"

--- a/docs/os/tutorials/blinky_primo.md
+++ b/docs/os/tutorials/blinky_primo.md
@@ -152,7 +152,7 @@ App image succesfully generated: ~/dev/myproj/bin/targets/primoblinky/app/apps/b
 
 **Note:** If you are using the OpenOCD debugger,  you do not need to attach this connector. 
 
-### Load the Bootloader and the Blinky Application Image
+### Load the Bootloader
 Run the `newt load primo_boot` command to load the bootloader onto the board:
 
 ```no-highlight
@@ -160,7 +160,16 @@ $ newt load primo_boot
 Loading bootloader
 $
 ```
+
+**Note:** If you are using OpenOCD on a Windows platform and you get an `unable to find CMSIS-DAP device` error, you will need to download and install the mbed Windows serial port driver from [https://developer.mbed.org/handbook/Windows-serial-configuration](https://developer.mbed.org/handbook/Windows-serial-configuration). Follow the instructions from the site to install the driver.  Here are some additional notes about the installation:
+
+1. The instructions indicate that the mbed Windows serial port driver is not required for Windows 10. If you are using Windows 10 and get the `unable to find CMSIS-DAP device` error, we recommend that you install the driver.
+2. If the driver installation fails, we recommend that you unplug the board, plug it back in, and retry the installation.
+
+Run the `newt load primo_boot` command again.
+
 <br>
+###Load the Blinky Application Image
 Run the `newt load primoblinky` command to load the Blinky application image onto the board.
 
 ```no-highlight
@@ -175,7 +184,7 @@ Note: If the LED does not blink, try resetting the board.
 
 
 <br>
-
+###Erase Flash
 If you want to erase the flash and load the image again, use JLinkExe and issue the `erase` command when you are using the Jlink debug probe: 
  
 **Note:** On Windows: Run the `jlink` command with the same arguments from a Windows Command Prompt terminal.

--- a/docs/os/tutorials/blinky_stm32f4disc.md
+++ b/docs/os/tutorials/blinky_stm32f4disc.md
@@ -157,7 +157,7 @@ $newt load stm32f4disc_boot
 Loading bootloader
 ```
 
-Note: If you are using Windows and get a `open failed` or  `no device found` error, you will need to install the usb driver. Download [Zadig](http://zadig.akeo.ie) and run it:
+Note: If you are using Windows and get an `open failed` or  `no device found` error, you will need to install the usb driver. Download [Zadig](http://zadig.akeo.ie) and run it:
 
 * Select Options > List All Devices.
 * Select `STM32 STLink` from the drop down menu.

--- a/docs/os/tutorials/blinky_stm32f4disc.md
+++ b/docs/os/tutorials/blinky_stm32f4disc.md
@@ -156,6 +156,15 @@ Run the `newt load stm32f4disc_boot` command to load the bootloader onto the boa
 $newt load stm32f4disc_boot
 Loading bootloader
 ```
+
+Note: If you are using Windows and get a `open failed` or  `no device found` error, you will need to install the usb driver. Download [Zadig](http://zadig.akeo.ie) and run it:
+
+* Select Options > List All Devices.
+* Select `STM32 STLink` from the drop down menu.
+* Select the `WinUSB` driver.
+* Click Install Driver.
+* Run the `newt load stm32f4disc_boot` command again.
+
 <br>
 Run the `newt load stm32f4disc_blinky` command to load the Blinky application image onto the board.
 ```no-highlight

--- a/docs/os/tutorials/olimex.md
+++ b/docs/os/tutorials/olimex.md
@@ -158,11 +158,11 @@ Load command: ~/dev/myproj/repos/apache-mynewt-core/hw/bsp/olimex_stm32-e407_dev
 Successfully loaded image.
 ```
 
-Note: If you are using Windows and get the `no device found` error, you will need to install the usb drivers for your Olimex debugger. Download [Zadig](http://zadig.akeo.ie) and run it:
+Note: If you are using Windows and get a `no device found` error, you will need to install the usb driver. Download [Zadig](http://zadig.akeo.ie) and run it:
 
 * Select Options > List All Devices.
-* Select Olimex OpenOCD JTAG ARM-USB-TINY-H from the drop down menu.
-* Select the WinUSB drivers.
+* Select `Olimex OpenOCD JTAG ARM-USB-TINY-H` from the drop down menu.
+* Select the `WinUSB` driver.
 * Click Install Driver.
 * Run the `newt load boot_olimex` command again. 
 

--- a/docs/os/tutorials/project-stm32-slinky.md
+++ b/docs/os/tutorials/project-stm32-slinky.md
@@ -129,6 +129,15 @@ Loading bootloader
 $
 ```
 <br>
+Note: If you are using Windows and get a `no device found` error, you will need to install the usb driver. Download [Zadig](http://zadig.akeo.ie) and run it:
+
+* Select Options > List All Devices.
+* Select `Olimex OpenOCD JTAG ARM-USB-TINY-H` from the drop down menu.
+* Select the `WinUSB` driver.
+* Click Install Driver.
+* Run the `newt load stm32_boot` command again.
+
+<br>
 Run the `newt load stm32_slinky` command to load the Slinky application image onto the board:
 ```no-highlight
 $ newt load stm32_slinky

--- a/docs/os/tutorials/rbnano2.md
+++ b/docs/os/tutorials/rbnano2.md
@@ -130,7 +130,7 @@ App image succesfully generated: ~/dev/myproj/bin/targets/rbnano2_blinky/app/app
 Connect the RedBear Nano 2 USB to a USB port on your computer. You should see an orange LED light up on the board.
 
         
-### Load the Bootloader and the Blinky Application Image
+### Load the Bootloader 
 
 Run the `newt load rbnano2_boot` command to load the bootloader onto the board: 
 
@@ -140,7 +140,17 @@ Loading bootloader
 $
 ```
 <br>
-Note: The flash memory on the RedBear Nano 2 comes write protected from the factory. If you get an error loading the bootloader and you are using a brand new chip, you need to clear the write protection from the debugger and then load the bootloader again.  Run the `newt debug rbnano2_blinky` command and issue the following commands at the highlighted (gdb) prompts.  
+
+**Note:** On Windows platforms, if you get an `unable to find CMSIS-DAP device` error, you will need to download and install the mbed Windows serial port driver from [https://developer.mbed.org/handbook/Windows-serial-configuration](https://developer.mbed.org/handbook/Windows-serial-configuration). Follow the instructions from the site to install the driver.  Here are some additional notes about the installation:
+
+1. The instructions indicate that the mbed Windows serial port driver is not required for Windows 10. If you are using Windows 10 and get the `unable to find CMSIS-DAP device` error, we recommend that you install the driver.
+2. If the driver installation fails, we recommend that you unplug the board, plug it back in, and retry the installation.
+
+Run the `newt load rbnano2_boot` command again.
+
+<br>
+####Clear the Write Protection on the Flash Memory
+The flash memory on the RedBear Nano 2 comes write protected from the factory. If you get an error loading the bootloader and you are using a brand new chip, you need to clear the write protection from the debugger and then load the bootloader again.  Run the `newt debug rbnano2_blinky` command and issue the following commands at the highlighted (gdb) prompts.  
 
 **Note:** The output of the debug session below is for Mac OS and Linux platforms. On Windows, openocd and gdb are started in separate Windows Command Prompt terminals, and the terminals are automatically closed when you quit gdb. In addition,  the output of openocd is logged to the openocd.log file in your project's base directory instead of the terminal.
 
@@ -171,9 +181,10 @@ Error: Failed to read memory at 0x00009ef4
 0x70:0xffffffff0xffffffff0xffffffff0xffffffff
 (gdb)
 ```
-
 <br>
-Run the `newt load rbnano2_blinky` command to load the Blinky application image onto the board.
+### Load the Blinky Application Image
+<br>
+Run the `newt load rbnano2_blinky` command to load the Blinky application image onto the board:
 ```no-highlight
 $ newt load rbnano2_blinky
 Loading app image into slot 1

--- a/docs/os/tutorials/wi-fi_on_arduino.md
+++ b/docs/os/tutorials/wi-fi_on_arduino.md
@@ -59,14 +59,11 @@ low level operations. Sometimes this code is licensed only for the specific manu
 To fetch the package with MCU support for Atmel SAMD21 for Arduino Zero from the Runtime git repository, you need to add
 the repository to the `project.yml` file in your base project directory (`arduinowifi`).
 
-```
-user@~/dev/arduinowifi$ vi project.yml
-```
-
 Here is an example ```project.yml``` file with the Arduino Zero repository
 added. The sections with ```mynewt_arduino_zero``` that need to be added to
 your project file are highlighted.
 
+**Note:** On Windows platforms: You need to set `vers` to `0-dev` and use the latest master branch for both repositories.
 
 ```hl_lines="6 14 15 16 17 18"
 $ more project.yml


### PR DESCRIPTION
1. Fix typo in newt install on Windows
2. Tell Windows users to set vers  to 0-dev and use the master branch for the apache-mynewt-core and mynewt_arduino_zero repo.
3. More boards need to install usb driver on Windows 7 than Windows 10.
4. Fix typo in newtmgr install on Windows
5. Add instructions to install mbed serial port driver for primo and nano2 .
    This does not include the additional instructions for Windows 7 users to install updated driver from  arduino to get primo to work. Need to decide if we want to package the drivers and put on runtimeco.