### PR TITLE
Updated ide, windows installation, and primo blinky tutorial.

### DIFF
--- a/docs/faq/ide.md
+++ b/docs/faq/ide.md
@@ -13,6 +13,9 @@ Prerequisites:
 * Have Internet connectivity to fetch remote Mynewt components.
 * Have a computer to build a Mynewt application.
 * Perform [native installation](/os/get_started/native_install_intro.md) for the Mynewt tools and toolchains.
+	
+	**Note:** For Windows platforms, ensure that the MinGW bash you install is added to your Windows Path. In addition, if you are using Windows 10 WSL, you must have the MinGW bash before the Windows 10 WSL bash in your Windows Path.
+
 * Read the Mynewt OS Concepts section.
 * Create a project space (directory structure) and populate it with the core code repository (apache-mynewt-core) or know how to as explained in Creating Your First Project.  
 * Complete one of the [Blinky Tutorials](/os/tutorials/blinky.md).
@@ -21,7 +24,7 @@ Prerequisites:
 
 * This guide is not a tutorial for Visual Studio Code. It assumes you are familiar with Visual Studio Code. If this is your first time using Visual Studio Code, we recommend that you read the Visual Studio Code [documentation and tutorials](https://code.visualstudio.com/docs) and evaluate whether you would like to use it to develop Mynewt applications. 
 * This guide uses Visual Studio Code on Windows. Visual Studio Code is supported on Linux and Mac OS but may have some variations in the keyboard shortcuts and command names for these platforms. 
-* You can also use the Eclipse IDE to develop Mynewt applications. See [https://www.codecoup.pl/blog/hacking-mynewt-in-eclipse](https://www.codecoup.pl/blog/hacking-mynewt-in-eclipse) for more details.
+* You can also use the Eclipse IDE to develop Mynewt applications. See [https://www.codecoup.pl/blog/hacking-mynewt-in-eclipse](https://www.codecoup.pl/blog/hacking-mynewt-in-eclipse) for more details. On Windows platforms, you must also ensure the MinGW bash is set in your Windows Path as described in the prerequisites.
 
 ###Installing Visual Studio Code
 Download and install Visual Studio Code from [https://code.visualstudio.com/](https://code.visualstudio.com/).
@@ -67,7 +70,7 @@ You define Visual Studio Code tasks to build and debug your Mynewt targets in Vi
 
 Perform the following steps to create the tasks to build and debug the Arduino blinky bootloader and appliction targets:
 
-Step 1: Press `Ctrl-Shift-P`, type `task` in the search box, and select **Tasks:Configure Task Runner** from the search results.  
+Step 1: Press `Ctrl-Shift-P`, type `task`, and select **Tasks:Configure Task Runner** from the search results.  
 
 Step 2: Select **Others** (scroll down to the bottom of the list) to create a task runner for external commands. 
 <br>
@@ -133,7 +136,7 @@ For more information on tasks and all supported properties, see the [Visual Stud
 <br>
 ####Running a Task
 
-To run a task, select `Ctrl-Shift-P`, type `task`, and select **Tasks: Run Task**.  The tasks that you define in the `tasks.json` file are listed.  Select the task to run. 
+To run a task, press `Ctrl-Shift-P`, type `task` on the search box, and select **Tasks: Run Task**.  The tasks that you define in the `tasks.json` file are listed.  Select the task to run. 
 
 The following is an example of running the `build_arduino_boot` task:
 <br>
@@ -143,9 +146,13 @@ The following is an example of running the `build_arduino_boot` task:
 <p align="center"><img src="/faq/pics/task_start_small.png"></p>
 
 <br>
+
+**Note**:To run the `build_arduino_linky` task, you can use the keyboard shortcut `Ctrl-Shift-B` because the task has the property `isBuildCommand` set to true.  
+
+<br>
 ####Defining Tasks for Other Newt Commands
 
-Other newt commands, such as the `newt load` command, do not need to run from within Visual Studio Code. You can define tasks for them as a convenience or run them on the command line from the Visual Studio Code integrated terminal (or an external terminal).
+Other newt commands, such as the `newt load` command, do not need to run from within Visual Studio Code. You can define a task for each command as a convenience and run the command as a task, or you can run the newt command on the command line from the Visual Studio Code integrated terminal or an external terminal.
 
 To create the tasks for the `newt load arduino_boot` and `newt laod arduino_blinky` commands, add the following definitions to the `tasks.json` file:
 
@@ -162,8 +169,10 @@ To create the tasks for the `newt load arduino_boot` and `newt laod arduino_blin
         }, 
 
 ```
+
+
 <br>
-To run the commands from the Visual Studio integrated terminal, press ``Ctrl-` `` to launch the integrated terminal and enter the command as shown:
+To run a command from the Visual Studio integrated terminal, instead of starting a task,  press ``Ctrl-` `` to launch the integrated terminal and enter the command on the prompt:
 <br>
 <p align="center"><img src="/faq/pics/integrated_terminal_small.png"></p>
 <br>
@@ -195,7 +204,7 @@ Step 2: Delete the content from the `launch.json` file, add the following defini
             "executable": "${workspaceRoot}\\bin\\targets\\arduino_blinky\\app\\apps\\blinky\\blinky.elf",
             "target": ":3333",
             "cwd": "${workspaceRoot}",
-            "gdbpath": "arm-none-eabi-gdb.exe",
+            "gdbpath": "C:\\Program Files (x86)\\GNU Tools ARM Embedded\\4.9 2015q2\\bin\\arm-none-eabi-gdb.exe",
             "remote": true
 
         }

--- a/docs/newt/install/newt_windows.md
+++ b/docs/newt/install/newt_windows.md
@@ -22,6 +22,9 @@ MSYS2/MinGW provides a bash shell and tools to build applications that run on Wi
 
 The subsystems run the bash shell and provide a Unix-like environment. You can also run Windows applications from the shell. We will use the MinGW subsystem.
 
+**Note:** You can skip this installation step if you already have MinGW installed (from an earlier MSYS2/MinGW or Git Bash installation), but you must list the **bin** path for your installation in your Windows Path. For example: if you installed MSYS2/MinGW in the ** C:\msys64 ** directory,  add **C:\msys64\usr\bin** to your Windows Path. If you are using Windows 10 WSL, ensure that you use the **C:\msys64\usr\bin\bash.exe** and not the Windows 10 WSL bash.
+
+
 To install and setup MSYS2 and MinGW:
 
 1. Download and run the [MSYS2 installer](http://www.msys2.org).  Select the 64 bit version if you are running on a 64 bit platform. Follow the prompts and check the `Run MSYS2 now` checkbox on the `Installation Complete` dialog. 
@@ -33,7 +36,12 @@ To install and setup MSYS2 and MinGW:
 	
 	To add the variable,  select properties for your computer > Advanced system settings > Environment Variables > New
 
-4. Run the `pacman -Su vim` command to install the vim editor. 
+4. Add the MinGW **bin** path to your Windows Path. For example: if you install MSYS2/MinGW in the **C:\msys64** directory,  add **C:\msys64\usr\bin** to your Windows Path. 
+
+	**Note:** If you are using Windows 10 WSL,  ensure that you use the **C:\msys64\usr\bin\bash.exe** and not the Windows 10 WSL bash.
+
+
+5. Run the `pacman -Su vim` command to install the vim editor. 
 	
 	**Note:**You can also use a Windows editor. You can access your files from the **C:\&lt;msys-install-folder&gt;\home\&lt;username&gt;** folder, where **msys-install-folder** is the folder you installed MSYS2 in. For example, if you installed MSYS2 in the **msys64** folder, your files are stored in **C:\msys64\home\&lt;username&gt;**
 

--- a/docs/os/get_started/native_install_intro.md
+++ b/docs/os/get_started/native_install_intro.md
@@ -21,3 +21,6 @@ The tools you need are:
     * Debuggers to load and debug applications on target boards. 
 	
 	(See [Installing Cross Tools for ARMs](/os/get_started/cross_tools.md)).
+
+
+If you would like to use an IDE to develop and debug Mynewt applications, see [using an IDE to develop Mynewt Applications](/faq/ide.md).  You must still perform the native installation outlined on this page.

--- a/docs/os/tutorials/blinky_primo.md
+++ b/docs/os/tutorials/blinky_primo.md
@@ -164,7 +164,14 @@ $
 **Note:** If you are using OpenOCD on a Windows platform and you get an `unable to find CMSIS-DAP device` error, you will need to download and install the mbed Windows serial port driver from [https://developer.mbed.org/handbook/Windows-serial-configuration](https://developer.mbed.org/handbook/Windows-serial-configuration). Follow the instructions from the site to install the driver.  Here are some additional notes about the installation:
 
 1. The instructions indicate that the mbed Windows serial port driver is not required for Windows 10. If you are using Windows 10 and get the `unable to find CMSIS-DAP device` error, we recommend that you install the driver.
-2. If the driver installation fails, we recommend that you unplug the board, plug it back in, and retry the installation.
+2. If the driver installation fails, we recommend that you download and install the Arduino Primo CMSIS-DAP driver. Perform the following steps: 
+
+    * Download the [Arduino Primo CMSIS-DAP driver](https://github.com/runtimeco/openocd-binaries/raw/master/arduino_primo_drivers.zip) and extract the zip file.
+    * Start Device Manager.
+    * Select **Other Devices** > **CMSIS-DAP CDC** > **Properties** > **Drivers** > **Update Driver...**.
+    * Select **Browse my computer for driver software**.
+    * Select the Arduino Driver folder where extracted the drivers to (check the include subfolders). Click **Next**  to install the driver.
+
 
 Run the `newt load primo_boot` command again.
 


### PR DESCRIPTION
1) IDE: Added note to ensure bash is in the path.
2) IDE: Added path to gdb.exe
3) Windows Installation: Added note to include bash in path.
4) Primo blinky tutorial: Added instructions to download and install arduino primo drivers.