### PR TITLE
Use nRF52 Development Kit (nRF52-DK)  in blinky nrf52 tutorial

### DIFF
--- a/docs/os/tutorials/blinky.md
+++ b/docs/os/tutorials/blinky.md
@@ -11,7 +11,7 @@ Tutorials are available for the following boards:
 * [Blinky on an Arduino Zero](/os/tutorials/arduino_zero.md)
 * [Blinky on an Arduino Primo](/os/tutorials/blinky_primo.md)
 * [Blinky on an Olimex](/os/tutorials/olimex.md)
-* [Blinky on a nRF52](/os/tutorials/nRF52.md)
+* [Blinky on a nRF52 Development Kit](/os/tutorials/nRF52.md)
 * [Blinky on a RedBear Nano 2](/os/tutorials/rbnano2.md)
 * [Blinky on a STM32F4-Discovery](/os/tutorials/blinky_stm32f4disc.md)
 

--- a/docs/os/tutorials/nRF52.md
+++ b/docs/os/tutorials/nRF52.md
@@ -1,8 +1,8 @@
-## Blinky, your "Hello World!", on nRF52
-This tutorial shows you how to create, build, and run the Blinky application on the nRF52 board.
+## Blinky, your "Hello World!", on a nRF52 Development Kit
+This tutorial shows you how to create, build, and run the Blinky application on a nRF52 Development Kit.
 <br>
 
-Note that there are several versions of the nRF52 in the market. The boards tested with this tutorial are listed under "Prerequisites".
+Note that there are several versions of the nRF52 Development Kit in the market. The boards tested with this tutorial are listed under "Prerequisites".
 
 <br>
 
@@ -10,8 +10,8 @@ Note that there are several versions of the nRF52 in the market. The boards test
 
 * Meet the prerequisites listed in [Project Blinky](/os/tutorials/blinky.md).
 * Have a nRF52 Development Kit (one of the following)
-    * Dev Kit from Nordic - PCA 10040
-    * Eval Kit from Rigado - BMD-300-EVAL-ES
+    * Nordic nRF52-DK Development Kit - PCA 10040
+    * Rigado BMD-300 Evaluation Kit - BMD-300-EVAL-ES
 * Install the [Segger JLINK Software and documentation pack](https://www.segger.com/jlink-software.html).
 
 This tutorial uses the Nordic nRF52-DK board.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,7 +35,7 @@ pages:
             - 'Blinky on Arduino Zero': 'os/tutorials/arduino_zero.md'
             - 'Blinky on Arduino Primo': 'os/tutorials/blinky_primo.md'
             - 'Blinky on Olimex': 'os/tutorials/olimex.md'
-            - 'Blinky on nRF52': 'os/tutorials/nRF52.md'
+            - 'Blinky on nRF52 DK': 'os/tutorials/nRF52.md'
             - 'Blinky on RedBear Nano 2': 'os/tutorials/rbnano2.md'
             - 'Blinky on STM32F4-Discovery': 'os/tutorials/blinky_stm32f4disc.md'
             - 'Add Console and Shell to Blinky': 'os/tutorials/blinky_console.md'


### PR DESCRIPTION
Use nRF52 Development Kit (nRF52-DK)  in blinky nrf52 tutorial to avoid confusion that the patched openocd currently works with nRF52-DK