### PR TITLE
MYNEWT-764 Document 1.1 newt run command behavior when version is not provided

### DIFF
--- a/docs/newt/command_list/newt_run.md
+++ b/docs/newt/command_list/newt_run.md
@@ -2,7 +2,10 @@
 
 A single command to do four steps - build a target, create-image, load image on a board, and start a debug session with the image on the board.
 
-**Note**: If the version number is omitted, the create-image step is skipped.
+**Note**: If the version number is omitted: 
+
+* The create-image step is skipped for a bootloader target.
+* You will be prompted to enter a version number for an application target.
 
 #### Usage: 
 


### PR DESCRIPTION
For version  1.1  added a note that when version number is not provided, create-image step is skipped for a bootloader target, and prompts the user to enter a version for an application target. 
