### PR TITLE
Removed outdated shell example.

### DIFF
--- a/docs/os/modules/shell/shell.md
+++ b/docs/os/modules/shell/shell.md
@@ -2,7 +2,7 @@
 
 The shell runs above the console and provides two functionalities:
 
-* Processes console input. 
+* Processes console input. See the [Enabling the Console and Shell Tutorial](/os/tutorials/add_shell.md) for an example of the shell.
 * Implements the [newtmgr](../../../newtmgr/overview.md) line protocol over serial transport. 
 
 The `sys/shell` package implements the shell.  The shell uses the OS default event queue 
@@ -25,83 +25,6 @@ calls the `shell_nlip_input_register()` function to register a handler that the 
 receives newtmgr request messages.
 
 <br>
-
-Create a sim target to check out these commands available in shell.
-
-```no-highlight
-user@~/dev$ newt target create blinky_sim
-Creating target blinky_sim
-Target blinky_sim successfully created!
-user@~/dev$ newt target set blinky_sim name=blinky_sim
-Target blinky_sim successfully set name to blinky_sim
-user@~/dev$ newt target set blinky_sim arch=sim
-Target blinky_sim successfully set arch to sim
-user@~/dev$ newt target set blinky_sim project=blinky
-Target blinky_sim successfully set project to blinky
-user@~/dev$ newt target set blinky_sim bsp=hw/bsp/native
-Target blinky_sim successfully set bsp to hw/bsp/native
-user@~/dev$ newt target set blinky_sim compiler_def=debug
-Target blinky_sim successfully set compiler_def to debug
-user@~/dev$ newt target set blinky_sim compiler=sim
-Target blinky_sim successfully set compiler to sim
-user@~/dev$ newt target show
-blinky_sim
-	arch: sim
-	bsp: hw/bsp/native
-	compiler: sim
-	compiler_def: debug
-	name: blinky_sim
-	project: blinky
-user@~/dev$ newt target build blinky_sim
-Building target blinky_sim (project = blinky)
-Compiling case.c
-Compiling suite.c
-Compiling testutil.c
-..
-..
-Building project blinky
-Linking blinky.elf
-Successfully run!
-
-user@~/dev$ ./project/blinky/bin/blinky_sim/blinky.elf
-uart0 at /dev/ttys005
-
-```
-
-Open up a new terminal to run minicom, a text-based serial port control and terminal emulation program. Set device name to the serial port of the target. 
-
-```no-highlight
-user@~$ minicom -D /dev/ttys005
-Welcome to minicom 2.7
-
-OPTIONS: 
-Compiled on Nov 24 2015, 16:14:21.
-Port /dev/ttys005, 11:32:17
-
-Press Meta-Z for help on special keys
-
-log 
-174578:[0] bla
-174578:[0] bab
-
-tasks
-217809:6 tasks: 
-217809:  shell (prio: 3, nw: 0, flags: 0x0, ssize: 0, cswcnt: 59, tot_run_time: 0ms)
-217840:  idle (prio: 255, nw: 0, flags: 0x0, ssize: 0, cswcnt: 18763, tot_run_time: 217809ms)
-217878:  uart_poller (prio: 0, nw: 217819, flags: 0x0, ssize: 0, cswcnt: 18667, tot_run_time: 0ms)
-217923:  task1 (prio: 1, nw: 218710, flags: 0x0, ssize: 0, cswcnt: 218, tot_run_time: 0ms)
-217953:  os_sanity (prio: 254, nw: 218710, flags: 0x0, ssize: 0, cswcnt: 218, tot_run_time: 0ms)
-218010:  task2 (prio: 2, nw: 217709, flags: 0x3, ssize: 0, cswcnt: 218, tot_run_time: 0ms)
-
-
-prompt
-Usage: prompt [set|show] [prompt_char]
-prompt set >
-Prompt set to: >
-229370: >
-
-```
-
 
 ###Data structures
 


### PR DESCRIPTION
This PR should be merged into 1.0 doc.  You can also merge this into the latest doc or just wait until the  PR for the 1.1 shell improvement doc is created. 
1) Removed the blinky shell example
2) Added a link the the enabling the Console and Shell tutorial as an example.