### PR TITLE
MYNEWT-768 - add newtmgr image erase subcommand.

### DIFF
--- a/docs/newtmgr/command_list/newtmgr_image.md
+++ b/docs/newtmgr/command_list/newtmgr_image.md
@@ -8,6 +8,11 @@ Manage images on a device.
 ```
 
 #### Flags:
+
+```no-highlight
+    -h, --help   help for image
+```
+<br>
 The coredownload subcommand uses the following local flags:
 
 ```no-highlight
@@ -16,15 +21,17 @@ The coredownload subcommand uses the following local flags:
         --offset unint32       Offset of the core file to start the download 
 
 ```
+<br>
 #### Global Flags:
 
 ```no-highlight
     -c, --conn string       connection profile to use
-    -h, --help              Help for newtmgr commands
     -l, --loglevel string   log level to use (default "info")
-    -t, --trace             print all bytes transmitted and received
+        --name string       name of target BLE device; overrides profile setting
+    -t, --timeout float     timeout in seconds (partial seconds allowed) (default 10)
+    -r, --tries int         total number of tries in case of timeout (default 1)
 ```
-
+<br>
 ####Description
 The image command provides subcommands to manage core and image files on a device.  Newtmgr uses the `conn_profile` connection profile to connect to the device.
 
@@ -35,6 +42,7 @@ coreconvert  | The newtmgr image coreconvert &lt;core-filename&gt; &lt;elf-file&
 coredownload | The newtmgr image coredownload &lt;core-filename&gt; command downloads the core file from a device and names the file `core-filename` on your host. Use the local flags under Flags to customize the command.
 coreerase    | The newtmgr image coreerase command erases the core file on a device.
 corelist     | The newtmgr image corelist command lists the core(s) on a device.
+erase        | The newtmgr image erase command erases an unused image from the secondary image slot on a device. The image cannot be erased if the image is a confirmed image, is marked for test on the next reboot, or is an active image for a split image setup. | 
 list         | The newtmgr image list command displays information for the images on a device.
 test         | The newtmgr test &lt;hex-image-hash&gt; command tests the image, identified by the `hex-image-hash` hash value, on next reboot.
 upload       | The newtmgr image upload &lt;image-file&gt; command uploads the `image-file` image file to a device.
@@ -51,6 +59,7 @@ coredownload | newtmgr image coredownload <br>mycore -e <br>-c profile01 | Downl
 coredownload | newtmgr image coredownload <br>mycore <br>--offset 10 -n 30<br>-c profile01 | Downloads 30 bytes, starting at offset 10, of the core from a device and saves it in the `mycore` file.   Newtmgr connects to the device over a connection specified in the `profile01` connection profile.
 coreerase    | newtmgr image coreerase <br>-c profile01 | Erases the core file on a device.  Newtmgr connects to the device over a connection specified in the `profile01` connection profile.
 corelist     | newtmgr image corelist<br>-c profile01 | Lists the core files on a device.  Newtmgr connects to the device over a connection specified in the `profile01` connection profile.
+erase     | newtmgr image erase<br>-c profile01 | Erases the image, if unused, from the secondary image slot on a device.  Newtmgr connects to the device over a connection specified in the `profile01` connection profile.
 list         | newtmgr image list<br>-c profile01 | Lists the images on a device.  Newtmgr connects to the device over a connection specified in the `profile01` connection profile.
 test         | newtmgr image test <br>be9699809a049...73d77f | Tests the image, identified by the `be9699809a049...73d77f` hash value, during the next reboot on a device. Newtmgr connects to the device over a connection specified in the `profile01` connection profile.  
 upload       | newtmgr image <br>upload bletiny.img<br>-c profile01 | Uploads the `bletiny.img` image to a device.  Newtmgr connects to the device over a connection specified in the `profile01` connection profile.


### PR DESCRIPTION
Added documentation for newtmgr image erase subcommand to support 
https://github.com/apache/incubator-mynewt-newt/pull/60