### PR TITLE
Add edit on github link

### DIFF
--- a/custom-theme/breadcrumbs.html
+++ b/custom-theme/breadcrumbs.html
@@ -1,5 +1,5 @@
 <div role="navigation" aria-label="breadcrumbs navigation">
-  <ul class="wy-breadcrumbs pull-right">
+  <ul class="wy-breadcrumbs">
     <li><a href="/{{ config.extra.version }}/{{ config.extra.doc_path }}">Docs</a></li>
     {% if current_page %}
     {% for doc in current_page.ancestors %}
@@ -15,11 +15,16 @@
     {% endif %}
     {% if repo_url %}
       <li class="wy-breadcrumbs-aside">
-          {% if repo_name == 'GitHub' %}
-            <a href="{{ repo_url }}" class="icon icon-github"> Edit on GitHub</a>
-          {% elif repo_name == 'Bitbucket' %}
-            <a href="{{ repo_url }}" class="icon icon-bitbucket"> Edit on BitBucket</a>
-          {% endif %}
+        {%- block repo %}
+        {% if page and page.edit_url %}
+          <a href="{{ page.edit_url }}"
+          {%- if config.repo_name|lower == 'github' %}
+            class="icon icon-github"
+          {%- elif config.repo_name|lower == 'bitbucket' %}
+            class="icon icon-bitbucket"
+          {% endif %}> Edit on {{ config.repo_name }}</a>
+        {% endif %}
+        {%- endblock %}
       </li>
     {% endif %}
   </ul>

--- a/custom-theme/css/custom.css
+++ b/custom-theme/css/custom.css
@@ -461,3 +461,16 @@ code {
 .doc-header .col-sm-6 {
     padding-left: 0px;
 }
+
+.icon:before {
+    font-family: "FontAwesome";
+    display: inline-block;
+    font-style: normal;
+    font-weight: normal;
+    line-height: 1;
+    text-decoration: inherit;
+}
+
+.fa-github, .icon-github:before {
+    content: "";
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,7 @@
 site_name: Apache Mynewt
 site_url: http://mynewt.apache.org
+repo_url: https://github.com/apache/incubator-mynewt-site/
+edit_uri: blob/master/docs
 
 theme_dir: 'custom-theme'
 


### PR DESCRIPTION
Add settings and missing styling to get a link to the page you're viewing on the docs github repo. This will make contributing a lot easier, and will probably improve the quality of the documentation over time.

Had to remove the `float: right` on the breadcrumbs so they weren't crammed together with the github link (like it is originally in mkdocs).

## After change:
![after](https://user-images.githubusercontent.com/149725/27226366-fb3961bc-529e-11e7-9718-c607970b6234.png)

## Before change:
![before](https://user-images.githubusercontent.com/149725/27226358-f51a3e5a-529e-11e7-8355-b358191dc75b.png)
