### PR TITLE
Add outdated documentation warning banner

### DIFF
--- a/custom-theme/base.html
+++ b/custom-theme/base.html
@@ -82,6 +82,18 @@
                         <div class="doc-header">
                             {% include 'breadcrumbs.html' %}
                         </div>
+                        {% if config.extra.version != 'latest' and config.extra.version != 'develop' %}
+                          {% for version in config.extra.versions %}
+                            {% if config.extra.version == version.branch %}
+                              <div class="alert alert-danger">
+                                This is an old version of the documentation ({{ version.label }})!
+                                <a href="/latest{{ page.abs_url }}">
+                                   Click here to read the newest version.
+                                </a>
+                              </div>
+                            {% endif %}
+                          {% endfor %}
+                        {% endif %}
                         {% block content %}
                             {{ content }}
                         {% endblock %}


### PR DESCRIPTION
This adds a helpful banner to alert users when they are browsing outdated versions of the docs. It looks like this:

![](https://i.gyazo.com/77e29eb449c778d3aa287422b15e56b8.gif)